### PR TITLE
A convenience method in RhsContext

### DIFF
--- a/evrete-core/src/main/java/org/evrete/api/RhsContext.java
+++ b/evrete-core/src/main/java/org/evrete/api/RhsContext.java
@@ -116,4 +116,19 @@ public interface RhsContext {
         return (T) getObject(name);
     }
 
+    /**
+     * <p>
+     * A typed version of the {@code get()} method with explicit generic cast type.
+     * </p>
+     *
+     * @param name fact name
+     * @param type fact type
+     * @param <T>  cast type
+     * @return current instance
+     */
+    @SuppressWarnings("unused")
+    default <T> T get(Class<T> type, String name) {
+        return get(name);
+    }
+
 }


### PR DESCRIPTION
The new `get(Class<T> type, String name)` default method provides immediate generic type and allows to skip intermediate var declaration. 