### PR TITLE
fix(compiler): prevent NullpointerException for nullable rootEntryName

### DIFF
--- a/evrete-core/src/main/java/org/evrete/runtime/compiler/PackageExplorer.java
+++ b/evrete-core/src/main/java/org/evrete/runtime/compiler/PackageExplorer.java
@@ -135,6 +135,7 @@ class PackageExplorer {
                         String entryName = e.getName();
                         return
                                 !e.isDirectory()
+                                        && rootEntryName != null
                                         && entryName.startsWith(rootEntryName)
                                         && entryName.endsWith(CLASS_FILE_EXTENSION)
                                         && !entryName.endsWith(CLASS_MODULE_INFO)


### PR DESCRIPTION
rootEntryName can be nullable, e.g. for some manifest files within jars.