### PR TITLE
OSGi Support - Annotation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,6 @@ benchmark*.csv
 XLocalDev*.*
 *tests.jar
 
+**/*.project
+**/*.classpath
+**/.settings/*

--- a/evrete-code-samples/pom.xml
+++ b/evrete-code-samples/pom.xml
@@ -15,6 +15,11 @@
     <build>
         <plugins>
             <plugin>
+                <groupId>biz.aQute.bnd</groupId>
+                <artifactId>bnd-maven-plugin</artifactId>
+            </plugin>
+
+            <plugin>
                 <artifactId>maven-deploy-plugin</artifactId>
                 <configuration>
                     <skip>true</skip>

--- a/evrete-core/pom.xml
+++ b/evrete-core/pom.xml
@@ -36,6 +36,11 @@
                 <artifactId>maven-failsafe-plugin</artifactId>
             </plugin>
 
+            <plugin>
+                <groupId>biz.aQute.bnd</groupId>
+                <artifactId>bnd-maven-plugin</artifactId>
+            </plugin>
+
         </plugins>
     </build>
 
@@ -59,6 +64,20 @@
             <artifactId>junit-jupiter-params</artifactId>
             <version>${junit.version}</version>
             <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>biz.aQute.bnd</groupId>
+            <artifactId>biz.aQute.bnd.annotation</artifactId>
+            <version>${bnd.version}</version>
+            <scope>compile</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.osgi</groupId>
+            <artifactId>org.osgi.annotation.bundle</artifactId>
+            <version>${org.osgi.annotation.bundle.version}</version>
+            <scope>compile</scope>
         </dependency>
 
     </dependencies>

--- a/evrete-core/src/main/java/org/evrete/KnowledgeService.java
+++ b/evrete-core/src/main/java/org/evrete/KnowledgeService.java
@@ -5,6 +5,8 @@ import org.evrete.api.spi.*;
 import org.evrete.runtime.KnowledgeRuntime;
 import org.evrete.runtime.async.ForkJoinExecutor;
 
+import aQute.bnd.annotation.spi.ServiceConsumer;
+
 import java.io.*;
 import java.net.URL;
 import java.util.*;
@@ -16,6 +18,11 @@ import java.util.*;
  * required SPI implementations, and an instance of Java ExecutorService.
  * </p>
  */
+@ServiceConsumer(value = DSLKnowledgeProvider.class)
+@ServiceConsumer(value = MemoryFactoryProvider.class)
+@ServiceConsumer(value = ExpressionResolverProvider.class)
+@ServiceConsumer(value = TypeResolverProvider.class)
+@ServiceConsumer(value = LiteralRhsCompiler.class)
 public class KnowledgeService {
     private final Configuration configuration;
     private final ForkJoinExecutor executor;

--- a/evrete-core/src/main/java/org/evrete/api/annotations/package-info.java
+++ b/evrete-core/src/main/java/org/evrete/api/annotations/package-info.java
@@ -1,0 +1,2 @@
+@org.osgi.annotation.bundle.Export
+package org.evrete.api.annotations;

--- a/evrete-core/src/main/java/org/evrete/api/package-info.java
+++ b/evrete-core/src/main/java/org/evrete/api/package-info.java
@@ -1,0 +1,2 @@
+@org.osgi.annotation.bundle.Export
+package org.evrete.api;

--- a/evrete-core/src/main/java/org/evrete/api/spi/package-info.java
+++ b/evrete-core/src/main/java/org/evrete/api/spi/package-info.java
@@ -1,0 +1,2 @@
+@org.osgi.annotation.bundle.Export
+package org.evrete.api.spi;

--- a/evrete-core/src/main/java/org/evrete/collections/package-info.java
+++ b/evrete-core/src/main/java/org/evrete/collections/package-info.java
@@ -1,0 +1,2 @@
+@org.osgi.annotation.bundle.Export
+package org.evrete.collections;

--- a/evrete-core/src/main/java/org/evrete/package-info.java
+++ b/evrete-core/src/main/java/org/evrete/package-info.java
@@ -1,0 +1,2 @@
+@org.osgi.annotation.bundle.Export
+package org.evrete;

--- a/evrete-core/src/main/java/org/evrete/runtime/async/package-info.java
+++ b/evrete-core/src/main/java/org/evrete/runtime/async/package-info.java
@@ -1,0 +1,2 @@
+@org.osgi.annotation.bundle.Export
+package org.evrete.runtime.async;

--- a/evrete-core/src/main/java/org/evrete/runtime/compiler/package-info.java
+++ b/evrete-core/src/main/java/org/evrete/runtime/compiler/package-info.java
@@ -1,0 +1,2 @@
+@org.osgi.annotation.bundle.Export
+package org.evrete.runtime.compiler;

--- a/evrete-core/src/main/java/org/evrete/runtime/evaluation/package-info.java
+++ b/evrete-core/src/main/java/org/evrete/runtime/evaluation/package-info.java
@@ -1,0 +1,2 @@
+@org.osgi.annotation.bundle.Export
+package org.evrete.runtime.evaluation;

--- a/evrete-core/src/main/java/org/evrete/runtime/package-info.java
+++ b/evrete-core/src/main/java/org/evrete/runtime/package-info.java
@@ -1,0 +1,2 @@
+@org.osgi.annotation.bundle.Export
+package org.evrete.runtime;

--- a/evrete-core/src/main/java/org/evrete/spi/minimal/DefaultExpressionResolverProvider.java
+++ b/evrete-core/src/main/java/org/evrete/spi/minimal/DefaultExpressionResolverProvider.java
@@ -4,6 +4,9 @@ import org.evrete.api.ExpressionResolver;
 import org.evrete.api.RuntimeContext;
 import org.evrete.api.spi.ExpressionResolverProvider;
 
+import aQute.bnd.annotation.spi.ServiceProvider;
+
+@ServiceProvider(value = ExpressionResolverProvider.class)
 public class DefaultExpressionResolverProvider extends LeastImportantServiceProvider implements ExpressionResolverProvider {
 
     @Override

--- a/evrete-core/src/main/java/org/evrete/spi/minimal/DefaultLiteralRhsCompiler.java
+++ b/evrete-core/src/main/java/org/evrete/spi/minimal/DefaultLiteralRhsCompiler.java
@@ -7,10 +7,13 @@ import org.evrete.api.RuntimeContext;
 import org.evrete.api.spi.LiteralRhsCompiler;
 import org.evrete.runtime.compiler.CompilationException;
 
+import aQute.bnd.annotation.spi.ServiceProvider;
+
 import java.util.StringJoiner;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Consumer;
 
+@ServiceProvider(value = LiteralRhsCompiler.class)
 public class DefaultLiteralRhsCompiler extends LeastImportantServiceProvider implements LiteralRhsCompiler {
     private static final AtomicInteger classCounter = new AtomicInteger(0);
     private static final String classPackage = DefaultLiteralRhsCompiler.class.getPackage().getName() + ".rhs";

--- a/evrete-core/src/main/java/org/evrete/spi/minimal/DefaultMemoryFactoryProvider.java
+++ b/evrete-core/src/main/java/org/evrete/spi/minimal/DefaultMemoryFactoryProvider.java
@@ -1,11 +1,14 @@
 package org.evrete.spi.minimal;
 
+import java.util.WeakHashMap;
+
 import org.evrete.api.MemoryFactory;
 import org.evrete.api.RuntimeContext;
 import org.evrete.api.spi.MemoryFactoryProvider;
 
-import java.util.WeakHashMap;
+import aQute.bnd.annotation.spi.ServiceProvider;
 
+@ServiceProvider(value = MemoryFactoryProvider.class)
 public class DefaultMemoryFactoryProvider extends LeastImportantServiceProvider implements MemoryFactoryProvider {
     private final WeakHashMap<RuntimeContext<?>, DefaultMemoryFactory> instances = new WeakHashMap<>();
 

--- a/evrete-core/src/main/java/org/evrete/spi/minimal/DefaultTypeResolverProvider.java
+++ b/evrete-core/src/main/java/org/evrete/spi/minimal/DefaultTypeResolverProvider.java
@@ -3,6 +3,9 @@ package org.evrete.spi.minimal;
 import org.evrete.api.TypeResolver;
 import org.evrete.api.spi.TypeResolverProvider;
 
+import aQute.bnd.annotation.spi.ServiceProvider;
+
+@ServiceProvider(value = TypeResolverProvider.class)
 public class DefaultTypeResolverProvider extends LeastImportantServiceProvider implements TypeResolverProvider {
 
     @Override

--- a/evrete-core/src/main/java/org/evrete/spi/minimal/package-info.java
+++ b/evrete-core/src/main/java/org/evrete/spi/minimal/package-info.java
@@ -1,0 +1,2 @@
+@org.osgi.annotation.bundle.Export
+package org.evrete.spi.minimal;

--- a/evrete-core/src/main/java/org/evrete/util/package-info.java
+++ b/evrete-core/src/main/java/org/evrete/util/package-info.java
@@ -1,0 +1,2 @@
+@org.osgi.annotation.bundle.Export
+package org.evrete.util;

--- a/evrete-core/src/main/resources/META-INF/services/org.evrete.api.spi.ExpressionResolverProvider
+++ b/evrete-core/src/main/resources/META-INF/services/org.evrete.api.spi.ExpressionResolverProvider
@@ -1,1 +1,0 @@
-org.evrete.spi.minimal.DefaultExpressionResolverProvider

--- a/evrete-core/src/main/resources/META-INF/services/org.evrete.api.spi.LiteralRhsCompiler
+++ b/evrete-core/src/main/resources/META-INF/services/org.evrete.api.spi.LiteralRhsCompiler
@@ -1,1 +1,0 @@
-org.evrete.spi.minimal.DefaultLiteralRhsCompiler

--- a/evrete-core/src/main/resources/META-INF/services/org.evrete.api.spi.MemoryFactoryProvider
+++ b/evrete-core/src/main/resources/META-INF/services/org.evrete.api.spi.MemoryFactoryProvider
@@ -1,1 +1,0 @@
-org.evrete.spi.minimal.DefaultMemoryFactoryProvider

--- a/evrete-core/src/main/resources/META-INF/services/org.evrete.api.spi.TypeResolverProvider
+++ b/evrete-core/src/main/resources/META-INF/services/org.evrete.api.spi.TypeResolverProvider
@@ -1,1 +1,0 @@
-org.evrete.spi.minimal.DefaultTypeResolverProvider

--- a/evrete-dsl-java/pom.xml
+++ b/evrete-dsl-java/pom.xml
@@ -31,6 +31,11 @@
                 <artifactId>maven-surefire-plugin</artifactId>
             </plugin>
 
+            <plugin>
+                <groupId>biz.aQute.bnd</groupId>
+                <artifactId>bnd-maven-plugin</artifactId>
+            </plugin>
+
         </plugins>
     </build>
 
@@ -60,6 +65,20 @@
             <artifactId>junit-jupiter-params</artifactId>
             <version>${junit.version}</version>
             <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>biz.aQute.bnd</groupId>
+            <artifactId>biz.aQute.bnd.annotation</artifactId>
+            <version>${bnd.version}</version>
+            <scope>compile</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.osgi</groupId>
+            <artifactId>org.osgi.annotation.bundle</artifactId>
+            <version>${org.osgi.annotation.bundle.version}</version>
+            <scope>compile</scope>
         </dependency>
 
     </dependencies>

--- a/evrete-dsl-java/src/main/java/org/evrete/dsl/DSLClassProvider.java
+++ b/evrete-dsl-java/src/main/java/org/evrete/dsl/DSLClassProvider.java
@@ -3,6 +3,9 @@ package org.evrete.dsl;
 import org.evrete.KnowledgeService;
 import org.evrete.api.Knowledge;
 import org.evrete.api.TypeResolver;
+import org.evrete.api.spi.DSLKnowledgeProvider;
+
+import aQute.bnd.annotation.spi.ServiceProvider;
 
 import java.io.BufferedReader;
 import java.io.IOException;
@@ -10,6 +13,7 @@ import java.io.InputStream;
 import java.io.Reader;
 import java.net.URL;
 
+@ServiceProvider(value = DSLKnowledgeProvider.class)
 public class DSLClassProvider extends AbstractDSLProvider {
 
     private static Class<?>[] loadClasses(KnowledgeService service, Reader... streams) throws IOException {

--- a/evrete-dsl-java/src/main/java/org/evrete/dsl/DSLJarProvider.java
+++ b/evrete-dsl-java/src/main/java/org/evrete/dsl/DSLJarProvider.java
@@ -6,7 +6,10 @@ import org.evrete.api.JavaSourceCompiler;
 import org.evrete.api.Knowledge;
 import org.evrete.api.RuntimeContext;
 import org.evrete.api.TypeResolver;
+import org.evrete.api.spi.DSLKnowledgeProvider;
 import org.evrete.dsl.annotation.RuleSet;
+
+import aQute.bnd.annotation.spi.ServiceProvider;
 
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
@@ -17,6 +20,7 @@ import java.util.jar.JarInputStream;
 
 import static org.evrete.dsl.Utils.LOGGER;
 
+@ServiceProvider(value = DSLKnowledgeProvider.class)
 public class DSLJarProvider extends AbstractDSLProvider {
     static final String CLASSES_PROPERTY = "org.evrete.dsl.rule-classes";
     private static final String EMPTY_CLASSES = "";

--- a/evrete-dsl-java/src/main/java/org/evrete/dsl/DSLSourceProvider.java
+++ b/evrete-dsl-java/src/main/java/org/evrete/dsl/DSLSourceProvider.java
@@ -4,7 +4,10 @@ import org.evrete.KnowledgeService;
 import org.evrete.api.JavaSourceCompiler;
 import org.evrete.api.Knowledge;
 import org.evrete.api.TypeResolver;
+import org.evrete.api.spi.DSLKnowledgeProvider;
 import org.evrete.runtime.compiler.CompilationException;
+
+import aQute.bnd.annotation.spi.ServiceProvider;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -14,6 +17,7 @@ import java.util.logging.Level;
 
 import static org.evrete.dsl.Utils.LOGGER;
 
+@ServiceProvider(value = DSLKnowledgeProvider.class)
 public class DSLSourceProvider extends AbstractDSLProvider {
 
     private static final String CHARSET_PROPERTY = "org.evrete.source-charset";

--- a/evrete-dsl-java/src/main/java/org/evrete/dsl/annotation/package-info.java
+++ b/evrete-dsl-java/src/main/java/org/evrete/dsl/annotation/package-info.java
@@ -1,0 +1,2 @@
+@org.osgi.annotation.bundle.Export
+package org.evrete.dsl.annotation;

--- a/evrete-dsl-java/src/main/java/org/evrete/dsl/package-info.java
+++ b/evrete-dsl-java/src/main/java/org/evrete/dsl/package-info.java
@@ -1,0 +1,2 @@
+@org.osgi.annotation.bundle.Export
+package org.evrete.dsl;

--- a/evrete-dsl-java/src/main/resources/META-INF/services/org.evrete.api.spi.DSLKnowledgeProvider
+++ b/evrete-dsl-java/src/main/resources/META-INF/services/org.evrete.api.spi.DSLKnowledgeProvider
@@ -1,3 +1,0 @@
-org.evrete.dsl.DSLSourceProvider
-org.evrete.dsl.DSLClassProvider
-org.evrete.dsl.DSLJarProvider

--- a/evrete-jsr94/pom.xml
+++ b/evrete-jsr94/pom.xml
@@ -32,6 +32,11 @@
                     <attach>true</attach>
                 </configuration>
             </plugin>
+
+            <plugin>
+                <groupId>biz.aQute.bnd</groupId>
+                <artifactId>bnd-maven-plugin</artifactId>
+            </plugin>
         </plugins>
     </build>
 
@@ -76,6 +81,13 @@
             <version>1.1</version>
             <scope>provided</scope>
             <optional>true</optional>
+        </dependency>
+
+        <dependency>
+            <groupId>org.osgi</groupId>
+            <artifactId>org.osgi.annotation.bundle</artifactId>
+            <version>${org.osgi.annotation.bundle.version}</version>
+            <scope>compile</scope>
         </dependency>
 
     </dependencies>

--- a/evrete-jsr94/src/main/java/org/evrete/jsr94/package-info.java
+++ b/evrete-jsr94/src/main/java/org/evrete/jsr94/package-info.java
@@ -1,0 +1,2 @@
+@org.osgi.annotation.bundle.Export
+package org.evrete.jsr94;

--- a/pom.xml
+++ b/pom.xml
@@ -16,6 +16,8 @@
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <junit.version>5.9.2</junit.version>
         <jmh.version>1.34</jmh.version>
+        <bnd.version>7.0.0</bnd.version>
+        <org.osgi.annotation.bundle.version>2.0.0</org.osgi.annotation.bundle.version>
     </properties>
 
     <scm>
@@ -73,11 +75,7 @@
                 <version>3.3.0</version>
                 <configuration>
                     <archive>
-                        <manifestEntries>
-                            <Implementation-Title>${project.description}</Implementation-Title>
-                            <Implementation-Version>${project.version}</Implementation-Version>
-                            <Implementation-URL>https://www.evrete.org</Implementation-URL>
-                        </manifestEntries>
+                        <manifestFile>${project.build.outputDirectory}/META-INF/MANIFEST.MF</manifestFile>
                     </archive>
                 </configuration>
             </plugin>
@@ -166,6 +164,32 @@
                             <id>attach-javadocs</id>
                             <goals>
                                 <goal>jar</goal>
+                            </goals>
+                        </execution>
+                    </executions>
+                </plugin>
+                <plugin>
+                    <groupId>biz.aQute.bnd</groupId>
+                    <artifactId>bnd-maven-plugin</artifactId>
+                    <version>${bnd.version}</version>
+                    <configuration>
+                        <bnd><![CDATA[
+                            Implementation-Title: ${project.description}
+                            Implementation-Version: ${project.version}
+                            Implementation-URL: https://www.evrete.org
+                            
+                            SPDX-License-Identifier: ${project.licenses[0].name}
+                            
+                            -noextraheaders: true
+                            -reproducible: true
+
+                        ]]></bnd>
+                    </configuration>
+                    <executions>
+                        <execution>
+                            <id>bnd-process</id>
+                            <goals>
+                                <goal>bnd-process</goal>
                             </goals>
                         </execution>
                     </executions>


### PR DESCRIPTION
I would like to use evrete inside an [OSGi](https://www.osgi.org/resources/where-to-start/) Runtime.
For this it is important to have proper Bundle-Manifest Metadata.

Since writing Manifests could be very complex we generate then using `bnd-maven-plugin` that analyses code and the annotations from `bnd.annotations` and `orgs.osgi.annotations.bundle`.

At the Moment this PR does:

- generate Bundle-Manifests
- export packages to use for others
- ServiceLoader (@ServiceProvider,@ServiceConsumer)
  - generate ServiceLoader-Files
  - generate OSGI-Metadata for Services
  - generate OSGi- Require-Cap (osgi.service.processor and registrar)


@timothyjward: could you review this first draft?


Manifests in Print-Mode

evrete-core
```
 
[MANIFEST]

Build-Jdk-Spec                          22
Bundle-Description                      Java Rule Engine
Bundle-DocURL                           https://www.evrete.org/evrete-core
Bundle-License                          "MIT License";link="https://www.opensource.org/licenses/mit-license"
Bundle-ManifestVersion                  2
Bundle-Name                             evrete-core
Bundle-SCM                              connection="scm:git:https://github.com/evrete/evrete.git/evrete-core"
                                        developer-connection="scm:git:https://github.com/evrete/evrete.git/evrete-core"
                                        tag=HEAD
                                        url="https://github.com/evrete/evrete/evrete-core"
Bundle-SymbolicName                     evrete-core
Bundle-Version                          3.0.7.202402071523
Created-By                              Maven JAR Plugin 3.3.0
Export-Package                          org.evrete.api.annotations;version="3.0.7"
                                        org.evrete.api.spi;uses:="org.evrete,org.evrete.api,org.evrete.runtime.compiler";version="3.0.7"
                                        org.evrete.api;uses:="org.evrete,org.evrete.runtime,org.evrete.runtime.compiler";version="3.0.7"
                                        org.evrete.collections;version="0.0.1";uses:="org.evrete.api"
                                        org.evrete.runtime.async;uses:="org.evrete.runtime,org.evrete.runtime.evaluation";version="3.0.7"
                                        org.evrete.runtime.compiler;uses:="javax.lang.model.element,javax.tools,org.evrete.api";version="3.0.7"
                                        org.evrete.runtime.evaluation;uses:="org.evrete.api,org.evrete.runtime";version="3.0.7"
                                        org.evrete.runtime;uses:="org.evrete,org.evrete.api,org.evrete.collections,org.evrete.runtime.compiler,org.evrete.runtime.evaluation";version="3.0.7"
                                        org.evrete.spi.minimal;uses:="org.evrete.api,org.evrete.api.spi,org.evrete.runtime.compiler";version="3.0.7"
                                        org.evrete;uses:="org.evrete.api,org.evrete.api.spi,org.evrete.runtime.async";version="3.0.7"
Implementation-Title                    Java Rule Engine
Implementation-URL                      https://www.evrete.org
Implementation-Version                  3.0.07-SNAPSHOT
Import-Package                          java.io
                                        java.lang
                                        java.lang.annotation
                                        java.lang.invoke
                                        java.lang.reflect
                                        java.net
                                        java.nio.charset
                                        java.nio.file
                                        java.nio.file.spi
                                        java.util
                                        java.util.concurrent
                                        java.util.concurrent.atomic
                                        java.util.function
                                        java.util.jar
                                        java.util.logging
                                        java.util.regex
                                        java.util.stream
                                        java.util.zip
                                        javax.lang.model.element
                                        javax.tools
                                        org.evrete
                                        org.evrete.api
                                        org.evrete.api.spi
Manifest-Version                        1.0
Private-Package                         org.evrete.util
Provide-Capability                      osgi.service;objectClass:List<String>="org.evrete.api.spi.ExpressionResolverProvider";effective:=active
                                        osgi.service;objectClass:List<String>="org.evrete.api.spi.LiteralRhsCompiler";effective:=active
                                        osgi.service;objectClass:List<String>="org.evrete.api.spi.MemoryFactoryProvider";effective:=active
                                        osgi.service;objectClass:List<String>="org.evrete.api.spi.TypeResolverProvider";effective:=active
                                        osgi.serviceloader;osgi.serviceloader="org.evrete.api.spi.ExpressionResolverProvider";register:="org.evrete.spi.minimal.DefaultExpressionResolverProvider"
                                        osgi.serviceloader;osgi.serviceloader="org.evrete.api.spi.LiteralRhsCompiler";register:="org.evrete.spi.minimal.DefaultLiteralRhsCompiler"
                                        osgi.serviceloader;osgi.serviceloader="org.evrete.api.spi.MemoryFactoryProvider";register:="org.evrete.spi.minimal.DefaultMemoryFactoryProvider"
                                        osgi.serviceloader;osgi.serviceloader="org.evrete.api.spi.TypeResolverProvider";register:="org.evrete.spi.minimal.DefaultTypeResolverProvider"
Require-Capability                      osgi.ee;filter:="(&(osgi.ee=JavaSE)(version=1.8))"
                                        osgi.extender;filter:="(&(osgi.extender=osgi.serviceloader.processor)(version>=1.0.0)(!(version>=2.0.0)))"
                                        osgi.extender;filter:="(&(osgi.extender=osgi.serviceloader.registrar)(version>=1.0.0)(!(version>=2.0.0)))"
                                        osgi.serviceloader;filter:="(osgi.serviceloader=org.evrete.api.spi.DSLKnowledgeProvider)";osgi.serviceloader="org.evrete.api.spi.DSLKnowledgeProvider"
                                        osgi.serviceloader;filter:="(osgi.serviceloader=org.evrete.api.spi.ExpressionResolverProvider)";osgi.serviceloader="org.evrete.api.spi.ExpressionResolverProvider"
                                        osgi.serviceloader;filter:="(osgi.serviceloader=org.evrete.api.spi.LiteralRhsCompiler)";osgi.serviceloader="org.evrete.api.spi.LiteralRhsCompiler"
                                        osgi.serviceloader;filter:="(osgi.serviceloader=org.evrete.api.spi.MemoryFactoryProvider)";osgi.serviceloader="org.evrete.api.spi.MemoryFactoryProvider"
                                        osgi.serviceloader;filter:="(osgi.serviceloader=org.evrete.api.spi.TypeResolverProvider)";osgi.serviceloader="org.evrete.api.spi.TypeResolverProvider"
SPDX-License-Identifier                 MIT License


[IMPEXP]

Import-Package
  java.io                                
  java.lang                              
  java.lang.annotation                   
  java.lang.invoke                       
  java.lang.reflect                      
  java.net                               
  java.nio.charset                       
  java.nio.file                          
  java.nio.file.spi                      
  java.util                              
  java.util.concurrent                   
  java.util.concurrent.atomic            
  java.util.function                     
  java.util.jar                          
  java.util.logging                      
  java.util.regex                        
  java.util.stream                       
  java.util.zip                          
  javax.lang.model.element               
  javax.tools                            
  org.evrete                             
  org.evrete.api                         
  org.evrete.api.spi                     

Export-Package
  org.evrete                             {version=3.0.7}
  org.evrete.api                         {version=3.0.7}
  org.evrete.api.annotations             {version=3.0.7}
  org.evrete.api.spi                     {version=3.0.7}
  org.evrete.collections                 {version=0.0.1}
  org.evrete.runtime                     {version=3.0.7}
  org.evrete.runtime.async               {version=3.0.7}
  org.evrete.runtime.compiler            {version=3.0.7}
  org.evrete.runtime.evaluation          {version=3.0.7}
  org.evrete.spi.minimal                 {version=3.0.7}

[CAPABILITIES]

Provide-Capability
  osgi.service                           {objectClass=org.evrete.api.spi.ExpressionResolverProvider, effective:=active}
  osgi.serviceloader                     {osgi.serviceloader=org.evrete.api.spi.ExpressionResolverProvider, register:=org.evrete.spi.minimal.DefaultExpressionResolverProvider}
  osgi.serviceloader                     {osgi.serviceloader=org.evrete.api.spi.LiteralRhsCompiler, register:=org.evrete.spi.minimal.DefaultLiteralRhsCompiler}
  osgi.serviceloader                     {osgi.serviceloader=org.evrete.api.spi.MemoryFactoryProvider, register:=org.evrete.spi.minimal.DefaultMemoryFactoryProvider}
  osgi.serviceloader                     {osgi.serviceloader=org.evrete.api.spi.TypeResolverProvider, register:=org.evrete.spi.minimal.DefaultTypeResolverProvider}
  osgi.service                           {objectClass=org.evrete.api.spi.LiteralRhsCompiler, effective:=active}
  osgi.service                           {objectClass=org.evrete.api.spi.MemoryFactoryProvider, effective:=active}
  osgi.service                           {objectClass=org.evrete.api.spi.TypeResolverProvider, effective:=active}
Require-Capability
  osgi.ee                                {filter:=(&(osgi.ee=JavaSE)(version=1.8))}
  osgi.extender                          {filter:=(&(osgi.extender=osgi.serviceloader.processor)(version>=1.0.0)(!(version>=2.0.0)))}
  osgi.extender                          {filter:=(&(osgi.extender=osgi.serviceloader.registrar)(version>=1.0.0)(!(version>=2.0.0)))}
  osgi.serviceloader                     {filter:=(osgi.serviceloader=org.evrete.api.spi.DSLKnowledgeProvider), osgi.serviceloader=org.evrete.api.spi.DSLKnowledgeProvider}
  osgi.serviceloader                     {filter:=(osgi.serviceloader=org.evrete.api.spi.ExpressionResolverProvider), osgi.serviceloader=org.evrete.api.spi.ExpressionResolverProvider}
  osgi.serviceloader                     {filter:=(osgi.serviceloader=org.evrete.api.spi.LiteralRhsCompiler), osgi.serviceloader=org.evrete.api.spi.LiteralRhsCompiler}
  osgi.serviceloader                     {filter:=(osgi.serviceloader=org.evrete.api.spi.MemoryFactoryProvider), osgi.serviceloader=org.evrete.api.spi.MemoryFactoryProvider}
  osgi.serviceloader                     {filter:=(osgi.serviceloader=org.evrete.api.spi.TypeResolverProvider), osgi.serviceloader=org.evrete.api.spi.TypeResolverProvider}

[COMPONENTS]



[METATYPE]



[API USES]


[USES]

org.evrete                              org.evrete.api
                                        org.evrete.api.spi
                                        org.evrete.runtime
                                        org.evrete.runtime.async
org.evrete.api                          org.evrete
                                        org.evrete.runtime
                                        org.evrete.runtime.compiler
org.evrete.api.annotations              
org.evrete.api.spi                      org.evrete
                                        org.evrete.api
                                        org.evrete.runtime.compiler
org.evrete.collections                  org.evrete.api
                                        org.evrete.util
org.evrete.runtime                      org.evrete
                                        org.evrete.api
                                        org.evrete.api.spi
                                        org.evrete.collections
                                        org.evrete.runtime.async
                                        org.evrete.runtime.compiler
                                        org.evrete.runtime.evaluation
                                        org.evrete.util
org.evrete.runtime.async                org.evrete.api
                                        org.evrete.collections
                                        org.evrete.runtime
                                        org.evrete.runtime.evaluation
                                        org.evrete.util
org.evrete.runtime.compiler             javax.lang.model.element
                                        javax.tools
                                        org.evrete.api
                                        org.evrete.util
org.evrete.runtime.evaluation           org.evrete.api
                                        org.evrete.runtime
                                        org.evrete.util
org.evrete.spi.minimal                  org.evrete
                                        org.evrete.api
                                        org.evrete.api.spi
                                        org.evrete.collections
                                        org.evrete.runtime
                                        org.evrete.runtime.compiler
                                        org.evrete.util
org.evrete.util                         org.evrete
                                        org.evrete.api
                                        org.evrete.runtime
                                        org.evrete.runtime.evaluation
```
---
org.evrete.dsl
```
[MANIFEST]

Build-Jdk-Spec                          22
Bundle-Description                      Java Rule Engine
Bundle-DocURL                           https://www.evrete.org/evrete-dsl-java
Bundle-License                          "MIT License";link="https://www.opensource.org/licenses/mit-license"
Bundle-ManifestVersion                  2
Bundle-Name                             evrete-dsl-java
Bundle-SCM                              connection="scm:git:https://github.com/evrete/evrete.git/evrete-dsl-java"
                                        developer-connection="scm:git:https://github.com/evrete/evrete.git/evrete-dsl-java"
                                        tag=HEAD
                                        url="https://github.com/evrete/evrete/evrete-dsl-java"
Bundle-SymbolicName                     evrete-dsl-java
Bundle-Version                          3.0.7.202402071523
Created-By                              Maven JAR Plugin 3.3.0
Export-Package                          org.evrete.dsl.annotation;uses:="org.evrete.dsl";version="3.0.7"
                                        org.evrete.dsl;uses:="org.evrete,org.evrete.api";version="3.0.7"
Implementation-Title                    Java Rule Engine
Implementation-URL                      https://www.evrete.org
Implementation-Version                  3.0.07-SNAPSHOT
Import-Package                          java.io
                                        java.lang
                                        java.lang.annotation
                                        java.lang.invoke
                                        java.lang.reflect
                                        java.net
                                        java.nio.charset
                                        java.util
                                        java.util.concurrent
                                        java.util.function
                                        java.util.jar
                                        java.util.logging
                                        org.evrete.api.spi;version="[3.0,4)"
                                        org.evrete.api;version="[3.0,4)"
                                        org.evrete.dsl
                                        org.evrete.dsl.annotation
                                        org.evrete.runtime.compiler;version="[3.0,4)"
                                        org.evrete.util
                                        org.evrete;version="[3.0,4)"
Manifest-Version                        1.0
Provide-Capability                      osgi.service;objectClass:List<String>="org.evrete.api.spi.DSLKnowledgeProvider";effective:=active
                                        osgi.serviceloader;osgi.serviceloader="org.evrete.api.spi.DSLKnowledgeProvider";register:="org.evrete.dsl.DSLClassProvider"
                                        osgi.serviceloader;osgi.serviceloader="org.evrete.api.spi.DSLKnowledgeProvider";register:="org.evrete.dsl.DSLJarProvider"
                                        osgi.serviceloader;osgi.serviceloader="org.evrete.api.spi.DSLKnowledgeProvider";register:="org.evrete.dsl.DSLSourceProvider"
Require-Capability                      osgi.ee;filter:="(&(osgi.ee=JavaSE)(version=1.8))"
                                        osgi.extender;filter:="(&(osgi.extender=osgi.serviceloader.registrar)(version>=1.0.0)(!(version>=2.0.0)))"
SPDX-License-Identifier                 MIT License


[IMPEXP]

Import-Package
  java.io                                
  java.lang                              
  java.lang.annotation                   
  java.lang.invoke                       
  java.lang.reflect                      
  java.net                               
  java.nio.charset                       
  java.util                              
  java.util.concurrent                   
  java.util.function                     
  java.util.jar                          
  java.util.logging                      
  org.evrete                             {version=[3.0,4)}
  org.evrete.api                         {version=[3.0,4)}
  org.evrete.api.spi                     {version=[3.0,4)}
  org.evrete.dsl                         
  org.evrete.dsl.annotation              
  org.evrete.runtime.compiler            {version=[3.0,4)}
  org.evrete.util                        

Export-Package
  org.evrete.dsl                         {version=3.0.7}
  org.evrete.dsl.annotation              {version=3.0.7}

[CAPABILITIES]

Provide-Capability
  osgi.service                           {objectClass=org.evrete.api.spi.DSLKnowledgeProvider, effective:=active}
  osgi.serviceloader                     {osgi.serviceloader=org.evrete.api.spi.DSLKnowledgeProvider, register:=org.evrete.dsl.DSLClassProvider}
  osgi.serviceloader                     {osgi.serviceloader=org.evrete.api.spi.DSLKnowledgeProvider, register:=org.evrete.dsl.DSLJarProvider}
  osgi.serviceloader                     {osgi.serviceloader=org.evrete.api.spi.DSLKnowledgeProvider, register:=org.evrete.dsl.DSLSourceProvider}
Require-Capability
  osgi.ee                                {filter:=(&(osgi.ee=JavaSE)(version=1.8))}
  osgi.extender                          {filter:=(&(osgi.extender=osgi.serviceloader.registrar)(version>=1.0.0)(!(version>=2.0.0)))}

[COMPONENTS]



[METATYPE]



[API USES]


[USES]

org.evrete.dsl                          org.evrete
                                        org.evrete.api
                                        org.evrete.api.spi
                                        org.evrete.dsl.annotation
                                        org.evrete.runtime.compiler
                                        org.evrete.util
org.evrete.dsl.annotation               org.evrete.dsl


```
---
evrete-jsr94
```
[MANIFEST]

Build-Jdk-Spec                          22
Bundle-Description                      Java Rule Engine
Bundle-DocURL                           https://www.evrete.org/evrete-jsr94
Bundle-License                          "MIT License";link="https://www.opensource.org/licenses/mit-license"
Bundle-ManifestVersion                  2
Bundle-Name                             evrete-jsr94
Bundle-SCM                              connection="scm:git:https://github.com/evrete/evrete.git/evrete-jsr94"
                                        developer-connection="scm:git:https://github.com/evrete/evrete.git/evrete-jsr94"
                                        tag=HEAD
                                        url="https://github.com/evrete/evrete/evrete-jsr94"
Bundle-SymbolicName                     evrete-jsr94
Bundle-Version                          3.0.7.202402071523
Created-By                              Maven JAR Plugin 3.3.0
Export-Package                          org.evrete.jsr94;uses:="javax.rules,javax.rules.admin";version="3.0.7"
Implementation-Title                    Java Rule Engine
Implementation-URL                      https://www.evrete.org
Implementation-Version                  3.0.07-SNAPSHOT
Import-Package                          java.io
                                        java.lang
                                        java.lang.invoke
                                        java.net
                                        java.util
                                        java.util.concurrent
                                        java.util.function
                                        java.util.logging
                                        java.util.stream
                                        javax.rules
                                        javax.rules.admin
                                        org.evrete.api;version="[3.0,4)"
                                        org.evrete.runtime;version="[3.0,4)"
                                        org.evrete;version="[3.0,4)"
                                        org.w3c.dom
Manifest-Version                        1.0
Require-Capability                      osgi.ee;filter:="(&(osgi.ee=JavaSE)(version=1.8))"
SPDX-License-Identifier                 MIT License


[IMPEXP]

Import-Package
  java.io                                
  java.lang                              
  java.lang.invoke                       
  java.net                               
  java.util                              
  java.util.concurrent                   
  java.util.function                     
  java.util.logging                      
  java.util.stream                       
  javax.rules                            
  javax.rules.admin                      
  org.evrete                             {version=[3.0,4)}
  org.evrete.api                         {version=[3.0,4)}
  org.evrete.runtime                     {version=[3.0,4)}
  org.w3c.dom                            

Export-Package
  org.evrete.jsr94                       {version=3.0.7}

[CAPABILITIES]

Require-Capability
  osgi.ee                                {filter:=(&(osgi.ee=JavaSE)(version=1.8))}

[COMPONENTS]



[METATYPE]



[API USES]


[USES]

org.evrete.jsr94                        javax.rules
                                        javax.rules.admin
                                        org.evrete
                                        org.evrete.api
                                        org.evrete.runtime
                                        org.w3c.dom

```