### PR TITLE
OSGi Support - manual

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,7 @@ benchmark*.csv
 XLocalDev*.*
 *tests.jar
 
+**/*.project
+**/*.classpath
+**/.settings/*
+

--- a/evrete-code-samples/pom.xml
+++ b/evrete-code-samples/pom.xml
@@ -15,6 +15,11 @@
     <build>
         <plugins>
             <plugin>
+                <groupId>biz.aQute.bnd</groupId>
+                <artifactId>bnd-maven-plugin</artifactId>
+            </plugin>
+
+            <plugin>
                 <artifactId>maven-deploy-plugin</artifactId>
                 <configuration>
                     <skip>true</skip>

--- a/evrete-core/pom.xml
+++ b/evrete-core/pom.xml
@@ -39,8 +39,14 @@
             <plugin>
                 <groupId>biz.aQute.bnd</groupId>
                 <artifactId>bnd-maven-plugin</artifactId>
-                <configuration>
-                        <bnd><![CDATA[
+                <executions>
+                    <execution>
+                        <id>jar</id>
+                        <goals>
+                            <goal>jar</goal>
+                        </goals>
+                        <configuration>
+                            <bnd><![CDATA[
                             Export-Package: org.evrete*
 
                             Provide-Capability:\
@@ -76,7 +82,8 @@
                                     filter:="(&(osgi.extender=osgi.serviceloader.registrar)(version>=1.0.0)(!(version>=2.0.0)))",\
                                 osgi.serviceloader;\
                                     filter:="(osgi.serviceloader=org.evrete.api.spi.DSLKnowledgeProvider)";\
-                                    osgi.serviceloader="org.evrete.api.spi.DSLKnowledgeProvider",\
+                                    osgi.serviceloader="org.evrete.api.spi.DSLKnowledgeProvider";\
+                                    resolution:=optional,\
                                 osgi.serviceloader;\
                                     filter:="(osgi.serviceloader=org.evrete.api.spi.ExpressionResolverProvider)";\
                                     osgi.serviceloader="org.evrete.api.spi.ExpressionResolverProvider",\
@@ -92,9 +99,83 @@
                                 osgi.ee;\
                                     filter:="(&(osgi.ee=JavaSE)(version=1.8))"
                         ]]></bnd>
-                    </configuration>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>test-jar</id>
+                        <goals>
+                            <goal>test-jar</goal>
+                        </goals>
+                        <configuration>
+                            <bnd><![CDATA[
+                            -noextraheaders: true
+                            -noimportjava: true
+                            ]]></bnd>
+                            <artifactFragment>true</artifactFragment>
+                            <testCases>all</testCases>
+                        </configuration>
+                    </execution>
+                </executions>
             </plugin>
 
+            <plugin>
+                <groupId>biz.aQute.bnd</groupId>
+                <artifactId>bnd-resolver-maven-plugin</artifactId>
+                <version>${bnd.version}</version>
+                <executions>
+                    <!-- Integration Test Configuration -->
+                    <execution>
+                        <id>resolve-test</id>
+                        <phase>pre-integration-test</phase>
+                        <goals>
+                            <goal>resolve</goal>
+                        </goals>
+                        <configuration>
+                            <bndruns>
+                                <include>test.bndrun</include>
+                            </bndruns>
+                            <bundles>
+                                <bundle>
+                                    ${project.build.directory}/${project.build.finalName}-tests.jar</bundle>
+                            </bundles>
+                            <failOnChanges>false</failOnChanges>
+                            <includeDependencyManagement>true</includeDependencyManagement>
+                            <reportOptional>false</reportOptional>
+                            <scopes>
+                                <scope>compile</scope>
+                                <scope>runtime</scope>
+                                <scope>test</scope>
+                            </scopes>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+
+            <plugin>
+                <groupId>biz.aQute.bnd</groupId>
+                <artifactId>bnd-testing-maven-plugin</artifactId>
+                <version>${bnd.version}</version>
+                <configuration>
+                    <failOnChanges>false</failOnChanges>
+                    <includeDependencyManagement>true</includeDependencyManagement>
+                    <resolve>true</resolve>
+                    <scopes>
+                        <scope>compile</scope>
+                        <scope>runtime</scope>
+                        <scope>test</scope>
+                    </scopes>
+                    <bndruns>
+                        <bndrun>test.bndrun</bndrun>
+                    </bndruns>
+                </configuration>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>testing</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
         </plugins>
     </build>
 
@@ -117,6 +198,33 @@
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-params</artifactId>
             <version>${junit.version}</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-params</artifactId>
+            <version>${junit.version}</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.junit.platform</groupId>
+            <artifactId>junit-platform-launcher</artifactId>
+            <version>${junit.platform.version}</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.eclipse.platform</groupId>
+            <artifactId>org.eclipse.osgi</artifactId>
+            <version>3.18.600</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.aries.spifly</groupId>
+            <artifactId>org.apache.aries.spifly.dynamic.framework.extension</artifactId>
+            <version>1.3.7</version>
             <scope>test</scope>
         </dependency>
 

--- a/evrete-core/pom.xml
+++ b/evrete-core/pom.xml
@@ -36,6 +36,65 @@
                 <artifactId>maven-failsafe-plugin</artifactId>
             </plugin>
 
+            <plugin>
+                <groupId>biz.aQute.bnd</groupId>
+                <artifactId>bnd-maven-plugin</artifactId>
+                <configuration>
+                        <bnd><![CDATA[
+                            Export-Package: org.evrete*
+
+                            Provide-Capability:\
+                                osgi.service;\
+                                    objectClass:List<String>="org.evrete.api.spi.ExpressionResolverProvider";\
+                                    effective:=active,\
+                                osgi.service;\
+                                    objectClass:List<String>="org.evrete.api.spi.LiteralRhsCompiler";\
+                                    effective:=active,\
+                                osgi.service;\
+                                    objectClass:List<String>="org.evrete.api.spi.MemoryFactoryProvider";\
+                                    effective:=active,\
+                                osgi.service;\
+                                    objectClass:List<String>="org.evrete.api.spi.TypeResolverProvider";\
+                                    effective:=active,\
+                                osgi.serviceloader;\
+                                    osgi.serviceloader="org.evrete.api.spi.ExpressionResolverProvider";\
+                                    register:="org.evrete.spi.minimal.DefaultExpressionResolverProvider",\
+                                osgi.serviceloader;\
+                                    osgi.serviceloader="org.evrete.api.spi.LiteralRhsCompiler";\
+                                    register:="org.evrete.spi.minimal.DefaultLiteralRhsCompiler",\
+                                osgi.serviceloader;\
+                                    osgi.serviceloader="org.evrete.api.spi.MemoryFactoryProvider";\
+                                    register:="org.evrete.spi.minimal.DefaultMemoryFactoryProvider",\
+                                osgi.serviceloader;\
+                                    osgi.serviceloader="org.evrete.api.spi.TypeResolverProvider";\
+                                    register:="org.evrete.spi.minimal.DefaultTypeResolverProvider"
+ 
+                            Require-Capability:\
+                                osgi.extender;\
+                                    filter:="(&(osgi.extender=osgi.serviceloader.processor)(version>=1.0.0)(!(version>=2.0.0)))",\
+                                osgi.extender;\
+                                    filter:="(&(osgi.extender=osgi.serviceloader.registrar)(version>=1.0.0)(!(version>=2.0.0)))",\
+                                osgi.serviceloader;\
+                                    filter:="(osgi.serviceloader=org.evrete.api.spi.DSLKnowledgeProvider)";\
+                                    osgi.serviceloader="org.evrete.api.spi.DSLKnowledgeProvider",\
+                                osgi.serviceloader;\
+                                    filter:="(osgi.serviceloader=org.evrete.api.spi.ExpressionResolverProvider)";\
+                                    osgi.serviceloader="org.evrete.api.spi.ExpressionResolverProvider",\
+                                osgi.serviceloader;\
+                                    filter:="(osgi.serviceloader=org.evrete.api.spi.LiteralRhsCompiler)";\
+                                    osgi.serviceloader="org.evrete.api.spi.LiteralRhsCompiler",\
+                                osgi.serviceloader;\
+                                    filter:="(osgi.serviceloader=org.evrete.api.spi.MemoryFactoryProvider)";\
+                                    osgi.serviceloader="org.evrete.api.spi.MemoryFactoryProvider",\
+                                osgi.serviceloader;\
+                                    filter:="(osgi.serviceloader=org.evrete.api.spi.TypeResolverProvider)";\
+                                    osgi.serviceloader="org.evrete.api.spi.TypeResolverProvider",\
+                                osgi.ee;\
+                                    filter:="(&(osgi.ee=JavaSE)(version=1.8))"
+                        ]]></bnd>
+                    </configuration>
+            </plugin>
+
         </plugins>
     </build>
 

--- a/evrete-core/src/test/java/org/evrete/EvaluationContextTests.java
+++ b/evrete-core/src/test/java/org/evrete/EvaluationContextTests.java
@@ -1,8 +1,20 @@
 package org.evrete;
 
-import org.evrete.api.*;
+import java.util.LinkedList;
+import java.util.List;
+
+import org.evrete.api.ActivationMode;
+import org.evrete.api.Evaluator;
+import org.evrete.api.EvaluatorHandle;
+import org.evrete.api.FieldReference;
+import org.evrete.api.Knowledge;
+import org.evrete.api.LhsBuilder;
+import org.evrete.api.RuleBuilder;
+import org.evrete.api.StatefulSession;
+import org.evrete.api.ValuesPredicate;
 import org.evrete.classes.TypeA;
 import org.evrete.classes.TypeB;
+import org.evrete.helper.IgnoreTestInOSGi;
 import org.evrete.runtime.evaluation.EvaluatorOfPredicate;
 import org.evrete.spi.minimal.DefaultExpressionResolverProvider;
 import org.evrete.spi.minimal.DefaultLiteralRhsCompiler;
@@ -14,9 +26,6 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.EnumSource;
-
-import java.util.LinkedList;
-import java.util.List;
 
 class EvaluationContextTests {
     private static KnowledgeService service;
@@ -44,6 +53,7 @@ class EvaluationContextTests {
 
     @ParameterizedTest
     @EnumSource(ActivationMode.class)
+    @IgnoreTestInOSGi
     void testAlphaBeta(ActivationMode mode) throws Exception {
 
         RhsAssert rhsAssert = new RhsAssert(

--- a/evrete-core/src/test/java/org/evrete/EvaluationListenersTests.java
+++ b/evrete-core/src/test/java/org/evrete/EvaluationListenersTests.java
@@ -3,6 +3,7 @@ package org.evrete;
 import org.evrete.api.*;
 import org.evrete.classes.TypeA;
 import org.evrete.classes.TypeB;
+import org.evrete.helper.IgnoreTestInOSGi;
 import org.evrete.util.NextIntSupplier;
 import org.evrete.util.RhsAssert;
 import org.junit.jupiter.api.AfterAll;
@@ -34,6 +35,7 @@ class EvaluationListenersTests {
 
     @ParameterizedTest
     @EnumSource(ActivationMode.class)
+    @IgnoreTestInOSGi
     void plainTest(ActivationMode mode) {
         NextIntSupplier knowledgeListenerCounter = new NextIntSupplier();
         NextIntSupplier sessionListenerCounter = new NextIntSupplier();
@@ -82,6 +84,7 @@ class EvaluationListenersTests {
 
     @ParameterizedTest
     @EnumSource(ActivationMode.class)
+    @IgnoreTestInOSGi
     void testAlphaBeta(ActivationMode mode) {
         AtomicInteger knowledgeListenerCounter = new AtomicInteger(0);
         AtomicInteger sessionListenerCounter = new AtomicInteger(0);
@@ -139,6 +142,7 @@ class EvaluationListenersTests {
 
     @ParameterizedTest
     @EnumSource(ActivationMode.class)
+    @IgnoreTestInOSGi
     void testBeta(ActivationMode mode) {
         AtomicInteger sessionListenerCounter = new AtomicInteger(0);
 

--- a/evrete-core/src/test/java/org/evrete/HotDeploymentStatefulTests.java
+++ b/evrete-core/src/test/java/org/evrete/HotDeploymentStatefulTests.java
@@ -5,6 +5,7 @@ import org.evrete.classes.TypeA;
 import org.evrete.classes.TypeB;
 import org.evrete.classes.TypeC;
 import org.evrete.classes.TypeD;
+import org.evrete.helper.IgnoreTestInOSGi;
 import org.evrete.util.NextIntSupplier;
 import org.evrete.util.RhsAssert;
 import org.junit.jupiter.api.AfterAll;
@@ -59,6 +60,7 @@ class HotDeploymentStatefulTests {
 
     @ParameterizedTest
     @EnumSource(ActivationMode.class)
+    @IgnoreTestInOSGi
     void plainTest1(ActivationMode mode) {
         session.setActivationMode(mode);
         RhsAssert rhsAssert = new RhsAssert("$n", Integer.class);
@@ -168,6 +170,7 @@ class HotDeploymentStatefulTests {
 
     @ParameterizedTest
     @EnumSource(ActivationMode.class)
+    @IgnoreTestInOSGi
     void testCircularMultiFinal(ActivationMode mode) {
         session.setActivationMode(mode);
 
@@ -362,6 +365,7 @@ class HotDeploymentStatefulTests {
 
     @ParameterizedTest
     @EnumSource(ActivationMode.class)
+    @IgnoreTestInOSGi
     void testMixed1(ActivationMode mode) {
         session.setActivationMode(mode);
 
@@ -607,6 +611,7 @@ class HotDeploymentStatefulTests {
 
     @ParameterizedTest
     @EnumSource(ActivationMode.class)
+    @IgnoreTestInOSGi
     void testAlpha1(ActivationMode mode) {
         session.setActivationMode(mode);
 
@@ -655,6 +660,7 @@ class HotDeploymentStatefulTests {
 
     @ParameterizedTest
     @EnumSource(ActivationMode.class)
+    @IgnoreTestInOSGi
     void testAlpha2(ActivationMode mode) {
         session.setActivationMode(mode);
 
@@ -702,6 +708,7 @@ class HotDeploymentStatefulTests {
 
     @ParameterizedTest
     @EnumSource(ActivationMode.class)
+    @IgnoreTestInOSGi
     void testAlpha3(ActivationMode mode) {
         session.setActivationMode(mode);
 
@@ -852,6 +859,7 @@ class HotDeploymentStatefulTests {
 
     @ParameterizedTest
     @EnumSource(ActivationMode.class)
+    @IgnoreTestInOSGi
     void testAlpha5(ActivationMode mode) {
         session.setActivationMode(mode);
 
@@ -881,6 +889,7 @@ class HotDeploymentStatefulTests {
     // An "inverse" version of the previous test
     @ParameterizedTest
     @EnumSource(ActivationMode.class)
+    @IgnoreTestInOSGi
     void testAlpha6(ActivationMode mode) {
         session.setActivationMode(mode);
 
@@ -912,6 +921,7 @@ class HotDeploymentStatefulTests {
 
     @ParameterizedTest
     @EnumSource(ActivationMode.class)
+    @IgnoreTestInOSGi
     void testMixedMulti(ActivationMode mode) {
         session.setActivationMode(mode);
 

--- a/evrete-core/src/test/java/org/evrete/HotDeploymentStatelessTests.java
+++ b/evrete-core/src/test/java/org/evrete/HotDeploymentStatelessTests.java
@@ -5,6 +5,7 @@ import org.evrete.classes.TypeA;
 import org.evrete.classes.TypeB;
 import org.evrete.classes.TypeC;
 import org.evrete.classes.TypeD;
+import org.evrete.helper.IgnoreTestInOSGi;
 import org.evrete.util.NextIntSupplier;
 import org.evrete.util.RhsAssert;
 import org.junit.jupiter.api.AfterAll;
@@ -53,6 +54,7 @@ class HotDeploymentStatelessTests {
 
     @ParameterizedTest
     @EnumSource(ActivationMode.class)
+    @IgnoreTestInOSGi
     void plainTest1(ActivationMode mode) {
         session.setActivationMode(mode);
         RhsAssert rhsAssert = new RhsAssert("$n", Integer.class);
@@ -154,6 +156,7 @@ class HotDeploymentStatelessTests {
 
     @ParameterizedTest
     @EnumSource(ActivationMode.class)
+    @IgnoreTestInOSGi
     void testCircularMultiFinal(ActivationMode mode) {
         session.setActivationMode(mode);
 
@@ -316,6 +319,7 @@ class HotDeploymentStatelessTests {
 
     @ParameterizedTest
     @EnumSource(ActivationMode.class)
+    @IgnoreTestInOSGi
     void testMixed1(ActivationMode mode) {
         session.setActivationMode(mode);
 
@@ -477,6 +481,7 @@ class HotDeploymentStatelessTests {
 
     @ParameterizedTest
     @EnumSource(ActivationMode.class)
+    @IgnoreTestInOSGi
     void testAlpha1(ActivationMode mode) {
         session.setActivationMode(mode);
 
@@ -517,6 +522,7 @@ class HotDeploymentStatelessTests {
 
     @ParameterizedTest
     @EnumSource(ActivationMode.class)
+    @IgnoreTestInOSGi
     void testAlpha2(ActivationMode mode) {
         session.setActivationMode(mode);
 
@@ -563,6 +569,7 @@ class HotDeploymentStatelessTests {
 
     @ParameterizedTest
     @EnumSource(ActivationMode.class)
+    @IgnoreTestInOSGi
     void testAlpha3(ActivationMode mode) {
         session.setActivationMode(mode);
 
@@ -662,6 +669,7 @@ class HotDeploymentStatelessTests {
 
     @ParameterizedTest
     @EnumSource(ActivationMode.class)
+    @IgnoreTestInOSGi
     void testAlpha5(ActivationMode mode) {
         session.setActivationMode(mode);
 

--- a/evrete-core/src/test/java/org/evrete/LiteralRhsTests.java
+++ b/evrete-core/src/test/java/org/evrete/LiteralRhsTests.java
@@ -4,6 +4,7 @@ import org.evrete.api.Knowledge;
 import org.evrete.api.RuleBuilder;
 import org.evrete.api.RuntimeRule;
 import org.evrete.api.StatefulSession;
+import org.evrete.helper.IgnoreTestInOSGi;
 import org.evrete.runtime.RuleDescriptor;
 import org.evrete.util.NextIntSupplier;
 import org.junit.jupiter.api.AfterAll;
@@ -36,6 +37,7 @@ public class LiteralRhsTests {
     }
 
     @Test
+    @IgnoreTestInOSGi
     void plainTest0() {
         knowledge
                 .addImport("org.evrete.LiteralRhsTests.SystemOut")
@@ -54,6 +56,7 @@ public class LiteralRhsTests {
     }
 
     @Test
+    @IgnoreTestInOSGi
     void plainTest1() {
         RuleBuilder<Knowledge> builder = knowledge
                 .addImport("org.evrete.LiteralRhsTests.SystemOut")
@@ -74,6 +77,7 @@ public class LiteralRhsTests {
     }
 
     @Test
+    @IgnoreTestInOSGi
     void plainTest2() {
         RuleBuilder<Knowledge> builder = knowledge
                 .addImport("org.evrete.LiteralRhsTests.SystemOut")

--- a/evrete-core/src/test/java/org/evrete/PredicatesTests.java
+++ b/evrete-core/src/test/java/org/evrete/PredicatesTests.java
@@ -8,6 +8,7 @@ import org.evrete.classes.TypeA;
 import org.evrete.classes.TypeB;
 import org.evrete.classes.TypeC;
 import org.evrete.classes.TypeD;
+import org.evrete.helper.IgnoreTestInOSGi;
 import org.evrete.util.RhsAssert;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
@@ -115,6 +116,7 @@ class PredicatesTests {
     }
 
     @Test
+    @IgnoreTestInOSGi
     void testCircularMultiFinal() {
 
         ValuesPredicate p1 = values -> {
@@ -608,6 +610,7 @@ class PredicatesTests {
     }
 
     @Test
+    @IgnoreTestInOSGi
     void testMethodInConditions1() {
         AtomicInteger counter = new AtomicInteger(0);
 
@@ -639,6 +642,7 @@ class PredicatesTests {
     }
 
     @Test
+    @IgnoreTestInOSGi
     void testMethodInConditions2() {
         AtomicInteger counter = new AtomicInteger(0);
 
@@ -668,6 +672,7 @@ class PredicatesTests {
     }
 
     @Test
+    @IgnoreTestInOSGi
     void testMethodInConditions3() {
         AtomicInteger counter = new AtomicInteger(0);
 
@@ -697,6 +702,7 @@ class PredicatesTests {
     }
 
     @Test
+    @IgnoreTestInOSGi
     void testMethodInConditions4() {
         AtomicInteger counter = new AtomicInteger(0);
 
@@ -726,6 +732,7 @@ class PredicatesTests {
     }
 
     @Test
+    @IgnoreTestInOSGi
     void testBaseConditionClass() {
         AtomicInteger counter = new AtomicInteger(0);
 

--- a/evrete-core/src/test/java/org/evrete/SessionUpdateDeleteTests.java
+++ b/evrete-core/src/test/java/org/evrete/SessionUpdateDeleteTests.java
@@ -5,6 +5,7 @@ import org.evrete.classes.TypeA;
 import org.evrete.classes.TypeB;
 import org.evrete.classes.TypeC;
 import org.evrete.helper.FactEntry;
+import org.evrete.helper.IgnoreTestInOSGi;
 import org.evrete.helper.TestUtils;
 import org.evrete.util.NextIntSupplier;
 import org.evrete.util.RhsAssert;
@@ -42,6 +43,7 @@ class SessionUpdateDeleteTests {
 
     @ParameterizedTest
     @EnumSource(ActivationMode.class)
+    @IgnoreTestInOSGi
     void updateAlpha1(ActivationMode mode) {
         NextIntSupplier counter = new NextIntSupplier();
         TypeA a = new TypeA();
@@ -65,6 +67,7 @@ class SessionUpdateDeleteTests {
 
     @ParameterizedTest
     @EnumSource(ActivationMode.class)
+    @IgnoreTestInOSGi
     void updateAlpha2(ActivationMode mode) {
         NextIntSupplier counter = new NextIntSupplier();
         TypeA ref = new TypeA();
@@ -87,6 +90,7 @@ class SessionUpdateDeleteTests {
 
     @ParameterizedTest
     @EnumSource(ActivationMode.class)
+    @IgnoreTestInOSGi
     void updateAlpha3(ActivationMode mode) {
         NextIntSupplier counter = new NextIntSupplier();
 
@@ -113,6 +117,7 @@ class SessionUpdateDeleteTests {
 
     @ParameterizedTest
     @EnumSource(ActivationMode.class)
+    @IgnoreTestInOSGi
     void retractBeta1(ActivationMode mode) {
         knowledge.newRule()
                 .forEach(
@@ -149,6 +154,7 @@ class SessionUpdateDeleteTests {
 
     @ParameterizedTest
     @EnumSource(ActivationMode.class)
+    @IgnoreTestInOSGi
     void statefulBetaUpdateDelete1(ActivationMode mode) {
         RhsAssert rhsAssert = new RhsAssert(
                 "$a", TypeA.class,
@@ -230,6 +236,7 @@ class SessionUpdateDeleteTests {
 
     @ParameterizedTest
     @EnumSource(ActivationMode.class)
+    @IgnoreTestInOSGi
     void updateBeta2(ActivationMode mode) {
         NextIntSupplier counter = new NextIntSupplier();
 
@@ -309,6 +316,7 @@ class SessionUpdateDeleteTests {
 
     @ParameterizedTest
     @EnumSource(ActivationMode.class)
+    @IgnoreTestInOSGi
     void updateBeta3(ActivationMode mode) {
         NextIntSupplier counter = new NextIntSupplier();
 
@@ -387,6 +395,7 @@ class SessionUpdateDeleteTests {
     }
 
     @Test
+    @IgnoreTestInOSGi
     void updateBeta2_mini() {
         NextIntSupplier counter = new NextIntSupplier();
 
@@ -464,6 +473,7 @@ class SessionUpdateDeleteTests {
 
     @ParameterizedTest
     @EnumSource(ActivationMode.class)
+    @IgnoreTestInOSGi
     void retractMemoryTest(ActivationMode mode) {
         NextIntSupplier counter = new NextIntSupplier();
 
@@ -521,6 +531,7 @@ class SessionUpdateDeleteTests {
 
     @ParameterizedTest
     @EnumSource(ActivationMode.class)
+    @IgnoreTestInOSGi
     void retractBeta(ActivationMode mode) {
 
         NextIntSupplier counter = new NextIntSupplier();
@@ -605,6 +616,7 @@ class SessionUpdateDeleteTests {
 
     @ParameterizedTest
     @EnumSource(ActivationMode.class)
+    @IgnoreTestInOSGi
     void primeNumbers1(ActivationMode mode) {
         knowledge.newRule("prime numbers")
                 .forEach(
@@ -637,6 +649,7 @@ class SessionUpdateDeleteTests {
 
     @ParameterizedTest
     @EnumSource(ActivationMode.class)
+    @IgnoreTestInOSGi
     void primeNumbers2(ActivationMode mode) {
         knowledge.newRule("prime numbers")
                 .forEach(
@@ -669,6 +682,7 @@ class SessionUpdateDeleteTests {
 
     @ParameterizedTest
     @EnumSource(ActivationMode.class)
+    @IgnoreTestInOSGi
     void externalUpdate1(ActivationMode mode) {
         NextIntSupplier counter = new NextIntSupplier();
         StatefulSession session = knowledge
@@ -708,6 +722,7 @@ class SessionUpdateDeleteTests {
 
     @ParameterizedTest
     @EnumSource(ActivationMode.class)
+    @IgnoreTestInOSGi
     void externalUpdate2(ActivationMode mode) {
         NextIntSupplier counter = new NextIntSupplier();
         StatefulSession session = knowledge
@@ -746,6 +761,7 @@ class SessionUpdateDeleteTests {
     }
 
     @Test
+    @IgnoreTestInOSGi
     void externalUpdate3() {
         NextIntSupplier counter = new NextIntSupplier();
 

--- a/evrete-core/src/test/java/org/evrete/StatefulBaseTests.java
+++ b/evrete-core/src/test/java/org/evrete/StatefulBaseTests.java
@@ -3,6 +3,7 @@ package org.evrete;
 import org.evrete.api.*;
 import org.evrete.classes.*;
 import org.evrete.helper.FactEntry;
+import org.evrete.helper.IgnoreTestInOSGi;
 import org.evrete.helper.TestUtils;
 import org.evrete.util.NextIntSupplier;
 import org.evrete.util.RhsAssert;
@@ -214,6 +215,7 @@ class StatefulBaseTests {
 
     @ParameterizedTest
     @EnumSource(ActivationMode.class)
+    @IgnoreTestInOSGi
     void plainTest1(ActivationMode mode) {
         RhsAssert rhsAssert = new RhsAssert("$n", Integer.class);
         knowledge.newRule()
@@ -287,6 +289,7 @@ class StatefulBaseTests {
 
     @ParameterizedTest
     @EnumSource(ActivationMode.class)
+    @IgnoreTestInOSGi
     void testMultiFinal1(ActivationMode mode) {
         knowledge.newRule()
                 .forEach(
@@ -335,6 +338,7 @@ class StatefulBaseTests {
 
     @ParameterizedTest
     @EnumSource(ActivationMode.class)
+    @IgnoreTestInOSGi
     void testMultiFinal2(ActivationMode mode) {
         String ruleName = "testMultiFinal2";
 
@@ -395,6 +399,7 @@ class StatefulBaseTests {
 
     @ParameterizedTest
     @EnumSource(ActivationMode.class)
+    @IgnoreTestInOSGi
     void testSingleFinalNode1(ActivationMode mode) {
 
         knowledge.newRule("testSingleFinalNode1")
@@ -461,6 +466,7 @@ class StatefulBaseTests {
 
     @ParameterizedTest
     @EnumSource(ActivationMode.class)
+    @IgnoreTestInOSGi
     void testCircularMultiFinal(ActivationMode mode) {
 
         knowledge.newRule("test circular")
@@ -524,6 +530,7 @@ class StatefulBaseTests {
 
     @ParameterizedTest
     @EnumSource(ActivationMode.class)
+    @IgnoreTestInOSGi
     void randomExpressionsTest(ActivationMode mode) {
         for (int objectCount = 1; objectCount < 8; objectCount++) {
             for (int conditions = 1; conditions < 8; conditions++) {
@@ -534,6 +541,7 @@ class StatefulBaseTests {
 
     @ParameterizedTest
     @EnumSource(ActivationMode.class)
+    @IgnoreTestInOSGi
     void testMultiFinal2_mini(ActivationMode mode) {
         String ruleName = "testMultiFinal2_mini";
 
@@ -590,6 +598,7 @@ class StatefulBaseTests {
 
     @ParameterizedTest
     @EnumSource(ActivationMode.class)
+    @IgnoreTestInOSGi
     void testFields(ActivationMode mode) {
         String ruleName = "testMultiFields";
 
@@ -635,6 +644,7 @@ class StatefulBaseTests {
 
     @ParameterizedTest
     @EnumSource(ActivationMode.class)
+    @IgnoreTestInOSGi
     void testSingleFinalNode2(ActivationMode mode) {
         knowledge.newRule("testSingleFinalNode2")
                 .forEach(
@@ -685,6 +695,7 @@ class StatefulBaseTests {
 
     @ParameterizedTest
     @EnumSource(ActivationMode.class)
+    @IgnoreTestInOSGi
     void testBeta1(ActivationMode mode) {
 
         RhsAssert rhsAssert = new RhsAssert(
@@ -730,6 +741,7 @@ class StatefulBaseTests {
 
     @ParameterizedTest
     @EnumSource(ActivationMode.class)
+    @IgnoreTestInOSGi
     void testAlphaBeta1(ActivationMode mode) {
         RhsAssert rhsAssert1 = new RhsAssert(
                 "$a", TypeA.class,
@@ -808,6 +820,7 @@ class StatefulBaseTests {
 
     @ParameterizedTest
     @EnumSource(ActivationMode.class)
+    @IgnoreTestInOSGi
     void testSimple1(ActivationMode mode) {
         RhsAssert rhsAssert = new RhsAssert(
                 "$a", TypeA.class,
@@ -844,6 +857,7 @@ class StatefulBaseTests {
 
     @ParameterizedTest
     @EnumSource(ActivationMode.class)
+    @IgnoreTestInOSGi
     void testSimple2(ActivationMode mode) {
         RhsAssert rhsAssert = new RhsAssert(
                 "$a", TypeA.class,
@@ -887,6 +901,7 @@ class StatefulBaseTests {
 
     @ParameterizedTest
     @EnumSource(ActivationMode.class)
+    @IgnoreTestInOSGi
     void testSimple3(ActivationMode mode) {
         RhsAssert rhsAssert = new RhsAssert(
                 "$a", TypeA.class,
@@ -950,6 +965,7 @@ class StatefulBaseTests {
 
     @ParameterizedTest
     @EnumSource(ActivationMode.class)
+    @IgnoreTestInOSGi
     void testSimple4(ActivationMode mode) {
         RhsAssert rhsAssert = new RhsAssert(
                 "$a", TypeA.class,
@@ -985,6 +1001,7 @@ class StatefulBaseTests {
 
     @ParameterizedTest
     @EnumSource(ActivationMode.class)
+    @IgnoreTestInOSGi
     void testUniType1(ActivationMode mode) {
         RhsAssert rhsAssert = new RhsAssert(
                 "$a1", TypeA.class,
@@ -1014,6 +1031,7 @@ class StatefulBaseTests {
 
     @ParameterizedTest
     @EnumSource(ActivationMode.class)
+    @IgnoreTestInOSGi
     void testUniType2(ActivationMode mode) {
         Set<String> collectedJoinedIds = new HashSet<>();
         knowledge.newRule("test uni 2")
@@ -1082,6 +1100,7 @@ class StatefulBaseTests {
 
     @ParameterizedTest
     @EnumSource(ActivationMode.class)
+    @IgnoreTestInOSGi
     void testUniType3(ActivationMode mode) {
         int rule = 0;
         RhsAssert rhsAssert = new RhsAssert(
@@ -1122,6 +1141,7 @@ class StatefulBaseTests {
 
     @ParameterizedTest
     @EnumSource(ActivationMode.class)
+    @IgnoreTestInOSGi
     void testUniType4(ActivationMode mode) {
         RhsAssert rhsAssert = new RhsAssert(
                 "$a1", TypeA.class,
@@ -1168,6 +1188,7 @@ class StatefulBaseTests {
 
     @ParameterizedTest
     @EnumSource(ActivationMode.class)
+    @IgnoreTestInOSGi
     void testAlphaBeta2(ActivationMode mode) {
         RhsAssert rhsAssert = new RhsAssert(
                 "$a", TypeA.class,
@@ -1212,6 +1233,7 @@ class StatefulBaseTests {
 
     @ParameterizedTest
     @EnumSource(ActivationMode.class)
+    @IgnoreTestInOSGi
     void testAlpha0(ActivationMode mode) {
         RhsAssert rhsAssert = new RhsAssert(
                 "$a", TypeA.class,
@@ -1246,6 +1268,7 @@ class StatefulBaseTests {
 
     @ParameterizedTest
     @EnumSource(ActivationMode.class)
+    @IgnoreTestInOSGi
     void testAlpha1(ActivationMode mode) {
         RhsAssert rhsAssert = new RhsAssert(
                 "$a", TypeA.class,
@@ -1296,6 +1319,7 @@ class StatefulBaseTests {
 
     @ParameterizedTest
     @EnumSource(ActivationMode.class)
+    @IgnoreTestInOSGi
     void testAlpha2(ActivationMode mode) {
         RhsAssert rhsAssert = new RhsAssert(
                 "$a", TypeA.class,
@@ -1344,6 +1368,7 @@ class StatefulBaseTests {
 
     @ParameterizedTest
     @EnumSource(ActivationMode.class)
+    @IgnoreTestInOSGi
     void testAlpha3(ActivationMode mode) {
         Configuration conf = knowledge.getConfiguration();
         conf.setProperty(Configuration.WARN_UNKNOWN_TYPES, "false");
@@ -1389,6 +1414,7 @@ class StatefulBaseTests {
 
     @ParameterizedTest
     @EnumSource(ActivationMode.class)
+    @IgnoreTestInOSGi
     void testAlpha4(ActivationMode mode) {
         RhsAssert rhsAssert1 = new RhsAssert("$a", TypeA.class);
         RhsAssert rhsAssert2 = new RhsAssert("$a", TypeA.class);
@@ -1425,6 +1451,7 @@ class StatefulBaseTests {
 
     @ParameterizedTest
     @EnumSource(ActivationMode.class)
+    @IgnoreTestInOSGi
     void testAlpha5(ActivationMode mode) {
         RhsAssert rhsAssert1 = new RhsAssert("$a", TypeA.class);
         RhsAssert rhsAssert2 = new RhsAssert("$a", TypeA.class);
@@ -1460,6 +1487,7 @@ class StatefulBaseTests {
 
     @ParameterizedTest
     @EnumSource(ActivationMode.class)
+    @IgnoreTestInOSGi
     void testAlpha6(ActivationMode mode) {
         RhsAssert rhsAssert = new RhsAssert(
                 "$a", TypeA.class,
@@ -1513,6 +1541,7 @@ class StatefulBaseTests {
 
     @ParameterizedTest
     @EnumSource(ActivationMode.class)
+    @IgnoreTestInOSGi
     void testMixed1(ActivationMode mode) {
         RhsAssert rhsAssert = new RhsAssert(
                 "$a1", TypeA.class,
@@ -1579,6 +1608,7 @@ class StatefulBaseTests {
 
     @ParameterizedTest
     @EnumSource(ActivationMode.class)
+    @IgnoreTestInOSGi
     void statefulBeta1(ActivationMode mode) {
 
         RhsAssert rhsAssert = new RhsAssert(

--- a/evrete-core/src/test/java/org/evrete/StatelessBaseTests.java
+++ b/evrete-core/src/test/java/org/evrete/StatelessBaseTests.java
@@ -2,6 +2,7 @@ package org.evrete;
 
 import org.evrete.api.*;
 import org.evrete.classes.*;
+import org.evrete.helper.IgnoreTestInOSGi;
 import org.evrete.util.NextIntSupplier;
 import org.evrete.util.RhsAssert;
 import org.junit.jupiter.api.AfterAll;
@@ -196,6 +197,7 @@ class StatelessBaseTests {
 
     @ParameterizedTest
     @EnumSource(ActivationMode.class)
+    @IgnoreTestInOSGi
     void plainTest1(ActivationMode mode) {
         RhsAssert rhsAssert = new RhsAssert("$n", Integer.class);
         knowledge.newRule()
@@ -254,6 +256,7 @@ class StatelessBaseTests {
 
     @ParameterizedTest
     @EnumSource(ActivationMode.class)
+    @IgnoreTestInOSGi
     void testMultiFinal1(ActivationMode mode) {
         knowledge.newRule()
                 .forEach(
@@ -303,6 +306,7 @@ class StatelessBaseTests {
 
     @ParameterizedTest
     @EnumSource(ActivationMode.class)
+    @IgnoreTestInOSGi
     void testMultiFinal2(ActivationMode mode) {
         String ruleName = "testMultiFinal2";
 
@@ -363,6 +367,7 @@ class StatelessBaseTests {
 
     @ParameterizedTest
     @EnumSource(ActivationMode.class)
+    @IgnoreTestInOSGi
     void testSingleFinalNode1(ActivationMode mode) {
 
         knowledge.newRule("testSingleFinalNode1")
@@ -429,6 +434,7 @@ class StatelessBaseTests {
 
     @ParameterizedTest
     @EnumSource(ActivationMode.class)
+    @IgnoreTestInOSGi
     void testCircularMultiFinal(ActivationMode mode) {
 
         knowledge.newRule("test circular")
@@ -492,6 +498,7 @@ class StatelessBaseTests {
 
     @ParameterizedTest
     @EnumSource(ActivationMode.class)
+    @IgnoreTestInOSGi
     void randomExpressionsTest(ActivationMode mode) {
         for (int objectCount = 1; objectCount < 8; objectCount++) {
             for (int conditions = 1; conditions < 8; conditions++) {
@@ -502,6 +509,7 @@ class StatelessBaseTests {
 
     @ParameterizedTest
     @EnumSource(ActivationMode.class)
+    @IgnoreTestInOSGi
     void testMultiFinal2_mini(ActivationMode mode) {
         String ruleName = "testMultiFinal2_mini";
 
@@ -540,6 +548,7 @@ class StatelessBaseTests {
 
     @ParameterizedTest
     @EnumSource(ActivationMode.class)
+    @IgnoreTestInOSGi
     void testFields(ActivationMode mode) {
         String ruleName = "testMultiFields";
 
@@ -571,6 +580,7 @@ class StatelessBaseTests {
 
     @ParameterizedTest
     @EnumSource(ActivationMode.class)
+    @IgnoreTestInOSGi
     void testSingleFinalNode2(ActivationMode mode) {
         knowledge.newRule("testSingleFinalNode2")
                 .forEach(
@@ -621,6 +631,7 @@ class StatelessBaseTests {
 
     @ParameterizedTest
     @EnumSource(ActivationMode.class)
+    @IgnoreTestInOSGi
     void testBeta1(ActivationMode mode) {
 
         RhsAssert rhsAssert = new RhsAssert(
@@ -656,6 +667,7 @@ class StatelessBaseTests {
 
     @ParameterizedTest
     @EnumSource(ActivationMode.class)
+    @IgnoreTestInOSGi
     void testAlphaBeta1(ActivationMode mode) {
         RhsAssert rhsAssert1 = new RhsAssert(
                 "$a", TypeA.class,
@@ -728,6 +740,7 @@ class StatelessBaseTests {
 
     @ParameterizedTest
     @EnumSource(ActivationMode.class)
+    @IgnoreTestInOSGi
     void testSimple1(ActivationMode mode) {
         RhsAssert rhsAssert = new RhsAssert(
                 "$a", TypeA.class,
@@ -763,6 +776,7 @@ class StatelessBaseTests {
 
     @ParameterizedTest
     @EnumSource(ActivationMode.class)
+    @IgnoreTestInOSGi
     void testSimple2(ActivationMode mode) {
         RhsAssert rhsAssert = new RhsAssert(
                 "$a", TypeA.class,
@@ -805,6 +819,7 @@ class StatelessBaseTests {
 
     @ParameterizedTest
     @EnumSource(ActivationMode.class)
+    @IgnoreTestInOSGi
     void testSimple3(ActivationMode mode) {
         RhsAssert rhsAssert = new RhsAssert(
                 "$a", TypeA.class,
@@ -867,6 +882,7 @@ class StatelessBaseTests {
 
     @ParameterizedTest
     @EnumSource(ActivationMode.class)
+    @IgnoreTestInOSGi
     void testSimple4(ActivationMode mode) {
         RhsAssert rhsAssert = new RhsAssert(
                 "$a", TypeA.class,
@@ -901,6 +917,7 @@ class StatelessBaseTests {
 
     @ParameterizedTest
     @EnumSource(ActivationMode.class)
+    @IgnoreTestInOSGi
     void testUniType1(ActivationMode mode) {
         RhsAssert rhsAssert = new RhsAssert(
                 "$a1", TypeA.class,
@@ -929,6 +946,7 @@ class StatelessBaseTests {
 
     @ParameterizedTest
     @EnumSource(ActivationMode.class)
+    @IgnoreTestInOSGi
     void testUniType3(ActivationMode mode) {
         int rule = 0;
         RhsAssert rhsAssert = new RhsAssert(
@@ -967,6 +985,7 @@ class StatelessBaseTests {
 
     @ParameterizedTest
     @EnumSource(ActivationMode.class)
+    @IgnoreTestInOSGi
     void testUniType4(ActivationMode mode) {
         RhsAssert rhsAssert = new RhsAssert(
                 "$a1", TypeA.class,
@@ -1012,6 +1031,7 @@ class StatelessBaseTests {
 
     @ParameterizedTest
     @EnumSource(ActivationMode.class)
+    @IgnoreTestInOSGi
     void testAlphaBeta2(ActivationMode mode) {
         RhsAssert rhsAssert = new RhsAssert(
                 "$a", TypeA.class,
@@ -1048,6 +1068,7 @@ class StatelessBaseTests {
 
     @ParameterizedTest
     @EnumSource(ActivationMode.class)
+    @IgnoreTestInOSGi
     void testAlpha0(ActivationMode mode) {
         RhsAssert rhsAssert = new RhsAssert(
                 "$a", TypeA.class,
@@ -1082,6 +1103,7 @@ class StatelessBaseTests {
 
     @ParameterizedTest
     @EnumSource(ActivationMode.class)
+    @IgnoreTestInOSGi
     void testAlpha3(ActivationMode mode) {
         Configuration conf = knowledge.getConfiguration();
         conf.setProperty(Configuration.WARN_UNKNOWN_TYPES, "false");
@@ -1126,6 +1148,7 @@ class StatelessBaseTests {
 
     @ParameterizedTest
     @EnumSource(ActivationMode.class)
+    @IgnoreTestInOSGi
     void testAlpha4(ActivationMode mode) {
         RhsAssert rhsAssert1 = new RhsAssert("$a", TypeA.class);
         RhsAssert rhsAssert2 = new RhsAssert("$a", TypeA.class);
@@ -1161,6 +1184,7 @@ class StatelessBaseTests {
 
     @ParameterizedTest
     @EnumSource(ActivationMode.class)
+    @IgnoreTestInOSGi
     void testAlpha5(ActivationMode mode) {
         RhsAssert rhsAssert1 = new RhsAssert("$a", TypeA.class);
         RhsAssert rhsAssert2 = new RhsAssert("$a", TypeA.class);
@@ -1195,6 +1219,7 @@ class StatelessBaseTests {
 
     @ParameterizedTest
     @EnumSource(ActivationMode.class)
+    @IgnoreTestInOSGi
     void testAlpha6(ActivationMode mode) {
         RhsAssert rhsAssert = new RhsAssert(
                 "$a", TypeA.class,
@@ -1225,6 +1250,7 @@ class StatelessBaseTests {
 
     @ParameterizedTest
     @EnumSource(ActivationMode.class)
+    @IgnoreTestInOSGi
     void testMixed1(ActivationMode mode) {
         RhsAssert rhsAssert = new RhsAssert(
                 "$a1", TypeA.class,
@@ -1274,6 +1300,7 @@ class StatelessBaseTests {
 
     @ParameterizedTest
     @EnumSource(ActivationMode.class)
+    @IgnoreTestInOSGi
     void statefulBeta1(ActivationMode mode) {
 
         RhsAssert rhsAssert = new RhsAssert(
@@ -1306,6 +1333,7 @@ class StatelessBaseTests {
 
     @ParameterizedTest
     @EnumSource(ActivationMode.class)
+    @IgnoreTestInOSGi
     void exceptionHandler1(ActivationMode mode) {
         RhsAssert rhsAssert1 = new RhsAssert("$a", TypeA.class);
         RhsAssert rhsAssert2 = new RhsAssert("$a", TypeA.class);
@@ -1346,6 +1374,7 @@ class StatelessBaseTests {
 
     @ParameterizedTest
     @EnumSource(ActivationMode.class)
+    @IgnoreTestInOSGi
     void exceptionHandler2(ActivationMode mode) {
 
         AtomicInteger exceptionCounter = new AtomicInteger();

--- a/evrete-core/src/test/java/org/evrete/helper/IgnoreTestInOSGi.java
+++ b/evrete-core/src/test/java/org/evrete/helper/IgnoreTestInOSGi.java
@@ -1,0 +1,14 @@
+package org.evrete.helper;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
+
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+@DisabledIfSystemProperty(named = "IgnoreInOSGiTest", matches = "true")
+public @interface IgnoreTestInOSGi {
+}

--- a/evrete-core/src/test/java/org/evrete/runtime/compiler/SourceCompilerTest.java
+++ b/evrete-core/src/test/java/org/evrete/runtime/compiler/SourceCompilerTest.java
@@ -1,6 +1,7 @@
 package org.evrete.runtime.compiler;
 
 import org.evrete.api.JavaSourceCompiler;
+import org.evrete.helper.IgnoreTestInOSGi;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -21,6 +22,7 @@ class SourceCompilerTest {
 
     @ParameterizedTest
     @ValueSource(booleans = {false, true})
+    @IgnoreTestInOSGi
     void compile1(boolean initClass) throws CompilationException, ClassNotFoundException {
 
         Assertions.assertThrows(
@@ -39,6 +41,7 @@ class SourceCompilerTest {
 
     @ParameterizedTest
     @ValueSource(booleans = {false, true})
+    @IgnoreTestInOSGi
     void compile2(boolean initClass) throws CompilationException, ClassNotFoundException {
 
         Assertions.assertThrows(
@@ -69,6 +72,7 @@ class SourceCompilerTest {
 
     @ParameterizedTest
     @ValueSource(booleans = {false, true})
+    @IgnoreTestInOSGi
     void compile3(boolean initClass) throws CompilationException, ClassNotFoundException {
 
         Assertions.assertThrows(
@@ -101,6 +105,7 @@ class SourceCompilerTest {
 
     @ParameterizedTest
     @ValueSource(booleans = {false, true})
+    @IgnoreTestInOSGi
     void compile4(boolean initClass) throws CompilationException, ClassNotFoundException {
 
         Assertions.assertThrows(
@@ -134,6 +139,7 @@ class SourceCompilerTest {
 
     @ParameterizedTest
     @ValueSource(booleans = {false, true})
+    @IgnoreTestInOSGi
     void compile5(boolean initClass) throws CompilationException, ClassNotFoundException {
 
         Assertions.assertThrows(
@@ -183,6 +189,7 @@ class SourceCompilerTest {
 
     @ParameterizedTest
     @ValueSource(booleans = {false, true})
+    @IgnoreTestInOSGi
     void compileNested1(boolean initClass) throws CompilationException, ClassNotFoundException {
 
         Assertions.assertThrows(
@@ -208,6 +215,7 @@ class SourceCompilerTest {
 
     @ParameterizedTest
     @ValueSource(booleans = {false, true})
+    @IgnoreTestInOSGi
     void compileNested2(boolean initClass) throws CompilationException, ClassNotFoundException {
 
         Assertions.assertThrows(

--- a/evrete-core/src/test/java/org/evrete/spi/minimal/DefaultFactStorageTest.java
+++ b/evrete-core/src/test/java/org/evrete/spi/minimal/DefaultFactStorageTest.java
@@ -5,6 +5,7 @@ import org.evrete.api.FactHandle;
 import org.evrete.api.FactStorage;
 import org.evrete.api.KeyMode;
 import org.evrete.classes.TypeA;
+import org.evrete.helper.IgnoreTestInOSGi;
 import org.evrete.runtime.KnowledgeRuntime;
 import org.evrete.runtime.StatefulSessionImpl;
 import org.evrete.runtime.TypeMemory;
@@ -34,6 +35,7 @@ class DefaultFactStorageTest {
     }
 
     @Test
+    @IgnoreTestInOSGi
     void update() {
         NextIntSupplier counter = new NextIntSupplier();
         int updates;

--- a/evrete-core/src/test/java/org/evrete/spi/minimal/EvaluatorCompilerTest.java
+++ b/evrete-core/src/test/java/org/evrete/spi/minimal/EvaluatorCompilerTest.java
@@ -7,6 +7,7 @@ import org.evrete.classes.TypeA;
 import org.evrete.classes.TypeB;
 import org.evrete.classes.TypeC;
 import org.evrete.classes.TypeD;
+import org.evrete.helper.IgnoreTestInOSGi;
 import org.evrete.runtime.KnowledgeRuntime;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
@@ -39,6 +40,7 @@ class EvaluatorCompilerTest {
     }
 
     @Test
+    @IgnoreTestInOSGi
     void testConditionBaseClass1() throws Exception {
 
         RuleBuilder<Knowledge> ruleBuilder = knowledge.newRule();
@@ -60,6 +62,7 @@ class EvaluatorCompilerTest {
     }
 
     @Test
+    @IgnoreTestInOSGi
     void testConditionBaseClass2() throws Exception {
 
         RuleBuilder<Knowledge> ruleBuilder = knowledge.newRule();

--- a/evrete-core/src/test/java/org/evrete/spi/minimal/ExpressionsTest.java
+++ b/evrete-core/src/test/java/org/evrete/spi/minimal/ExpressionsTest.java
@@ -6,6 +6,7 @@ import org.evrete.api.*;
 import org.evrete.classes.TypeA;
 import org.evrete.classes.TypeB;
 import org.evrete.classes.TypeC;
+import org.evrete.helper.IgnoreTestInOSGi;
 import org.evrete.runtime.KnowledgeRuntime;
 import org.evrete.runtime.compiler.CompilationException;
 import org.evrete.util.NextIntSupplier;
@@ -41,6 +42,7 @@ class ExpressionsTest {
     }
 
     @Test
+    @IgnoreTestInOSGi
     void test1() throws CompilationException {
         LhsBuilder<Knowledge> root = rule.forEach();
         assert root.addFactDeclaration("$a", TypeA.class).getName().equals("$a");
@@ -67,6 +69,7 @@ class ExpressionsTest {
     }
 
     @Test
+    @IgnoreTestInOSGi
     void test2() throws CompilationException {
         LhsBuilder<Knowledge> root = rule.forEach();
         assert root.addFactDeclaration("$a", TypeA.class).getName().equals("$a");
@@ -76,6 +79,7 @@ class ExpressionsTest {
     }
 
     @Test
+    @IgnoreTestInOSGi
     void test3() throws CompilationException {
 
         Configuration configuration = new Configuration();
@@ -92,6 +96,7 @@ class ExpressionsTest {
     }
 
     @Test
+    @IgnoreTestInOSGi
     void testNestedFields1() {
         NextIntSupplier counter = new NextIntSupplier();
         StatefulSession session = rule
@@ -113,6 +118,7 @@ class ExpressionsTest {
     }
 
     @Test
+    @IgnoreTestInOSGi
     void testNestedFields2() {
         NextIntSupplier counter = new NextIntSupplier();
         StatefulSession session = rule
@@ -133,6 +139,7 @@ class ExpressionsTest {
     }
 
     @Test
+    @IgnoreTestInOSGi
     void testThisFields2() {
         NextIntSupplier counter = new NextIntSupplier();
         StatefulSession session = rule
@@ -151,6 +158,7 @@ class ExpressionsTest {
     }
 
     @Test
+    @IgnoreTestInOSGi
     void testRepeatedReference() {
         NextIntSupplier counter = new NextIntSupplier();
         StatefulSession session = rule

--- a/evrete-core/src/test/java/org/evrete/spi/minimal/TypeResolverTest.java
+++ b/evrete-core/src/test/java/org/evrete/spi/minimal/TypeResolverTest.java
@@ -6,6 +6,7 @@ import org.evrete.api.Knowledge;
 import org.evrete.api.StatefulSession;
 import org.evrete.api.Type;
 import org.evrete.api.TypeResolver;
+import org.evrete.helper.IgnoreTestInOSGi;
 import org.evrete.util.RhsAssert;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
@@ -43,6 +44,7 @@ class TypeResolverTest {
     }
 
     @Test
+    @IgnoreTestInOSGi
     void testInheritance2() {
         RhsAssert rhsAssert = new RhsAssert("$s", StatefulSession.class);
         TypeResolver typeResolver = service.newTypeResolver();
@@ -62,6 +64,7 @@ class TypeResolverTest {
     }
 
     @Test
+    @IgnoreTestInOSGi
     void testInheritance3() {
         TypeResolver typeResolver = service.newTypeResolver();
         Type<StatefulSession> sessionType = typeResolver.declare(StatefulSession.class);

--- a/evrete-core/src/test/java/org/evrete/util/SessionCollectorTest.java
+++ b/evrete-core/src/test/java/org/evrete/util/SessionCollectorTest.java
@@ -3,6 +3,7 @@ package org.evrete.util;
 import org.evrete.KnowledgeService;
 import org.evrete.api.Knowledge;
 import org.evrete.api.StatefulSession;
+import org.evrete.helper.IgnoreTestInOSGi;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
@@ -26,6 +27,7 @@ class SessionCollectorTest {
 
     @SuppressWarnings("resource")
     @Test
+    @IgnoreTestInOSGi
     void statefulTest() {
         Knowledge knowledge = service
                 .newKnowledge()

--- a/evrete-core/test.bndrun
+++ b/evrete-core/test.bndrun
@@ -1,0 +1,29 @@
+-runstartlevel: \
+	order=sortbynameversion,\
+	begin=-1
+
+-runproperties:\
+	IgnoreInOSGiTest=true
+
+-runtrace: true
+
+-tester: biz.aQute.tester.junit-platform
+
+-runfw: org.eclipse.osgi
+-runee: JavaSE-1.8
+-runrequires: \
+	bnd.identity;id=junit-jupiter-engine,\
+	bnd.identity;id=junit-platform-launcher,\
+	bnd.identity;id=evrete-core-tests,\
+	bnd.identity;id=evrete-core
+-runbundles: \
+	evrete-core;version='[3.0.7,3.0.8)',\
+	evrete-core-tests;version='[3.0.7,3.0.8)',\
+	junit-jupiter-api;version='[5.9.2,5.9.3)',\
+	junit-jupiter-engine;version='[5.9.2,5.9.3)',\
+	junit-jupiter-params;version='[5.9.2,5.9.3)',\
+	junit-platform-commons;version='[1.9.2,1.9.3)',\
+	junit-platform-engine;version='[1.9.2,1.9.3)',\
+	junit-platform-launcher;version='[1.9.2,1.9.3)',\
+	org.apache.aries.spifly.dynamic.framework.extension;version='[1.3.7,1.3.8)',\
+	org.opentest4j;version='[1.2.0,1.2.1)'

--- a/evrete-dsl-java/pom.xml
+++ b/evrete-dsl-java/pom.xml
@@ -31,6 +31,35 @@
                 <artifactId>maven-surefire-plugin</artifactId>
             </plugin>
 
+            <plugin>
+                <groupId>biz.aQute.bnd</groupId>
+                <artifactId>bnd-maven-plugin</artifactId>
+                <configuration>
+                        <bnd><![CDATA[
+                            Export-Package: org.evrete.dsl*
+
+                            Provide-Capability:\
+                                osgi.service;\
+                                    objectClass:List<String>="org.evrete.api.spi.DSLKnowledgeProvider";\
+                                    effective:=active,\
+                                osgi.serviceloader;\
+                                    osgi.serviceloader="org.evrete.api.spi.DSLKnowledgeProvider";\
+                                    register:="org.evrete.dsl.DSLClassProvider",\
+                                osgi.serviceloader;\
+                                    osgi.serviceloader="org.evrete.api.spi.DSLKnowledgeProvider";\
+                                    register:="org.evrete.dsl.DSLJarProvider",\
+                                osgi.serviceloader;osgi.serviceloader="org.evrete.api.spi.DSLKnowledgeProvider";\
+                                    register:="org.evrete.dsl.DSLSourceProvider"\
+
+                                Require-Capability:\
+                                    osgi.extender;\
+                                        filter:="(&(osgi.extender=osgi.serviceloader.registrar)(version>=1.0.0)(!(version>=2.0.0)))",\
+                                    osgi.ee;\
+                                        filter:="(&(osgi.ee=JavaSE)(version=1.8))"
+                        ]]></bnd>
+                    </configuration>
+            </plugin>
+
         </plugins>
     </build>
 

--- a/evrete-jsr94/pom.xml
+++ b/evrete-jsr94/pom.xml
@@ -32,6 +32,20 @@
                     <attach>true</attach>
                 </configuration>
             </plugin>
+
+            <plugin>
+                <groupId>biz.aQute.bnd</groupId>
+                <artifactId>bnd-maven-plugin</artifactId>
+                <configuration>
+                        <bnd><![CDATA[
+                                Export-Package: org.evrete.jsr94*
+
+                                Require-Capability:\
+                                    osgi.ee;\
+                                        filter:="(&(osgi.ee=JavaSE)(version=1.8))"
+                        ]]></bnd>
+                </configuration>
+            </plugin>
         </plugins>
     </build>
 

--- a/evrete-osgi-test/bin/.gitignore
+++ b/evrete-osgi-test/bin/.gitignore
@@ -1,0 +1,1 @@
+/.settings/

--- a/pom.xml
+++ b/pom.xml
@@ -15,6 +15,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <junit.version>5.9.2</junit.version>
+        <junit.platform.version>1.9.2</junit.platform.version>
         <jmh.version>1.34</jmh.version>
         <bnd.version>6.4.0</bnd.version>
     </properties>
@@ -65,17 +66,6 @@
                     <compilerArgs>
                         <arg>-Xlint:deprecation</arg>
                     </compilerArgs>
-                </configuration>
-            </plugin>
-
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-jar-plugin</artifactId>
-                <version>3.3.0</version>
-                <configuration>
-                    <archive>
-                        <manifestFile>${project.build.outputDirectory}/META-INF/MANIFEST.MF</manifestFile>
-                    </archive>
                 </configuration>
             </plugin>
 
@@ -171,12 +161,13 @@
                     <groupId>biz.aQute.bnd</groupId>
                     <artifactId>bnd-maven-plugin</artifactId>
                     <version>${bnd.version}</version>
+                    <extensions>true</extensions>
                     <configuration>
                         <bnd><![CDATA[
                             Implementation-Title: ${project.description}
                             Implementation-Version: ${project.version}
                             Implementation-URL: https://www.evrete.org
-                            
+
                             SPDX-License-Identifier: ${project.licenses[0].name}
                             
                             -noextraheaders: true

--- a/pom.xml
+++ b/pom.xml
@@ -16,6 +16,7 @@
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <junit.version>5.9.2</junit.version>
         <jmh.version>1.34</jmh.version>
+        <bnd.version>6.4.0</bnd.version>
     </properties>
 
     <scm>
@@ -73,11 +74,7 @@
                 <version>3.3.0</version>
                 <configuration>
                     <archive>
-                        <manifestEntries>
-                            <Implementation-Title>${project.description}</Implementation-Title>
-                            <Implementation-Version>${project.version}</Implementation-Version>
-                            <Implementation-URL>https://www.evrete.org</Implementation-URL>
-                        </manifestEntries>
+                        <manifestFile>${project.build.outputDirectory}/META-INF/MANIFEST.MF</manifestFile>
                     </archive>
                 </configuration>
             </plugin>
@@ -166,6 +163,31 @@
                             <id>attach-javadocs</id>
                             <goals>
                                 <goal>jar</goal>
+                            </goals>
+                        </execution>
+                    </executions>
+                </plugin>
+                <plugin>
+                    <groupId>biz.aQute.bnd</groupId>
+                    <artifactId>bnd-maven-plugin</artifactId>
+                    <version>${bnd.version}</version>
+                    <configuration>
+                        <bnd><![CDATA[
+                            Implementation-Title: ${project.description}
+                            Implementation-Version: ${project.version}
+                            Implementation-URL: https://www.evrete.org
+                            
+                            SPDX-License-Identifier: ${project.licenses[0].name}
+                            
+                            -noextraheaders: true
+                            -reproducible: true
+                        ]]></bnd>
+                    </configuration>
+                    <executions>
+                        <execution>
+                            <id>bnd-process</id>
+                            <goals>
+                                <goal>bnd-process</goal>
                             </goals>
                         </execution>
                     </executions>


### PR DESCRIPTION
- generate Bundle-Manifests using manual description
- export packages to use for others
- ServiceLoader
  - add OSGI-Metadata for Services
  - add Require-Cap (osgi.service.processor and registrar)

Core Manifest - Print-Mode:
```
[MANIFEST]

Build-Jdk-Spec                          22
Bundle-Description                      Java Rule Engine
Bundle-DocURL                           https://www.evrete.org/evrete-core
Bundle-License                          "MIT License";link="https://www.opensource.org/licenses/mit-license"
Bundle-ManifestVersion                  2
Bundle-Name                             evrete-core
Bundle-SCM                              connection="scm:git:https://github.com/evrete/evrete.git/evrete-core"
                                        developer-connection="scm:git:https://github.com/evrete/evrete.git/evrete-core"
                                        tag=HEAD
                                        url="https://github.com/evrete/evrete/evrete-core"
Bundle-SymbolicName                     evrete-core
Bundle-Version                          3.0.7.202402081653
Created-By                              Maven JAR Plugin 3.3.0
Export-Package                          org.evrete.api.annotations;version="3.0.7"
                                        org.evrete.api.spi;uses:="org.evrete,org.evrete.api,org.evrete.runtime.compiler";version="3.0.7"
                                        org.evrete.api;uses:="org.evrete,org.evrete.runtime,org.evrete.runtime.compiler";version="3.0.7"
                                        org.evrete.collections;uses:="org.evrete.api";version="3.0.7"
                                        org.evrete.runtime.async;uses:="org.evrete.runtime,org.evrete.runtime.evaluation,org.evrete.util";version="3.0.7"
                                        org.evrete.runtime.compiler;uses:="javax.lang.model.element,javax.tools,org.evrete.api";version="3.0.7"
                                        org.evrete.runtime.evaluation;uses:="org.evrete.api,org.evrete.runtime,org.evrete.util";version="3.0.7"
                                        org.evrete.runtime;uses:="org.evrete,org.evrete.api,org.evrete.collections,org.evrete.runtime.compiler,org.evrete.runtime.evaluation,org.evrete.util";version="3.0.7"
                                        org.evrete.spi.minimal;uses:="org.evrete.api,org.evrete.api.spi,org.evrete.runtime.compiler";version="3.0.7"
                                        org.evrete.util;uses:="org.evrete,org.evrete.api,org.evrete.runtime,org.evrete.runtime.evaluation";version="3.0.7"
                                        org.evrete;uses:="org.evrete.api,org.evrete.api.spi,org.evrete.runtime.async";version="3.0.7"
Implementation-Title                    Java Rule Engine
Implementation-URL                      https://www.evrete.org
Implementation-Version                  3.0.07-SNAPSHOT
Import-Package                          javax.lang.model.element
                                        javax.tools
                                        org.evrete
                                        org.evrete.api
                                        org.evrete.api.spi
                                        org.evrete.collections
                                        org.evrete.runtime
                                        org.evrete.runtime.async
                                        org.evrete.runtime.compiler
                                        org.evrete.runtime.evaluation
                                        org.evrete.util
Manifest-Version                        1.0
Provide-Capability                      osgi.service;objectClass:List<String>="org.evrete.api.spi.ExpressionResolverProvider";effective:=active
                                        osgi.service;objectClass:List<String>="org.evrete.api.spi.LiteralRhsCompiler";effective:=active
                                        osgi.service;objectClass:List<String>="org.evrete.api.spi.MemoryFactoryProvider";effective:=active
                                        osgi.service;objectClass:List<String>="org.evrete.api.spi.TypeResolverProvider";effective:=active
                                        osgi.serviceloader;osgi.serviceloader="org.evrete.api.spi.ExpressionResolverProvider";register:="org.evrete.spi.minimal.DefaultExpressionResolverProvider"
                                        osgi.serviceloader;osgi.serviceloader="org.evrete.api.spi.LiteralRhsCompiler";register:="org.evrete.spi.minimal.DefaultLiteralRhsCompiler"
                                        osgi.serviceloader;osgi.serviceloader="org.evrete.api.spi.MemoryFactoryProvider";register:="org.evrete.spi.minimal.DefaultMemoryFactoryProvider"
                                        osgi.serviceloader;osgi.serviceloader="org.evrete.api.spi.TypeResolverProvider";register:="org.evrete.spi.minimal.DefaultTypeResolverProvider"
Require-Capability                      osgi.ee;filter:="(&(osgi.ee=JavaSE)(version=1.8))"
                                        osgi.extender;filter:="(&(osgi.extender=osgi.serviceloader.processor)(version>=1.0.0)(!(version>=2.0.0)))"
                                        osgi.extender;filter:="(&(osgi.extender=osgi.serviceloader.registrar)(version>=1.0.0)(!(version>=2.0.0)))"
                                        osgi.serviceloader;filter:="(osgi.serviceloader=org.evrete.api.spi.DSLKnowledgeProvider)";osgi.serviceloader="org.evrete.api.spi.DSLKnowledgeProvider"
                                        osgi.serviceloader;filter:="(osgi.serviceloader=org.evrete.api.spi.ExpressionResolverProvider)";osgi.serviceloader="org.evrete.api.spi.ExpressionResolverProvider"
                                        osgi.serviceloader;filter:="(osgi.serviceloader=org.evrete.api.spi.LiteralRhsCompiler)";osgi.serviceloader="org.evrete.api.spi.LiteralRhsCompiler"
                                        osgi.serviceloader;filter:="(osgi.serviceloader=org.evrete.api.spi.MemoryFactoryProvider)";osgi.serviceloader="org.evrete.api.spi.MemoryFactoryProvider"
                                        osgi.serviceloader;filter:="(osgi.serviceloader=org.evrete.api.spi.TypeResolverProvider)";osgi.serviceloader="org.evrete.api.spi.TypeResolverProvider"
SPDX-License-Identifier                 MIT License


[IMPEXP]

Import-Package
  javax.lang.model.element               
  javax.tools                            
  org.evrete                             
  org.evrete.api                         
  org.evrete.api.spi                     
  org.evrete.collections                 
  org.evrete.runtime                     
  org.evrete.runtime.async               
  org.evrete.runtime.compiler            
  org.evrete.runtime.evaluation          
  org.evrete.util                        

Export-Package
  org.evrete                             {version=3.0.7}
  org.evrete.api                         {version=3.0.7}
  org.evrete.api.annotations             {version=3.0.7}
  org.evrete.api.spi                     {version=3.0.7}
  org.evrete.collections                 {version=3.0.7}
  org.evrete.runtime                     {version=3.0.7}
  org.evrete.runtime.async               {version=3.0.7}
  org.evrete.runtime.compiler            {version=3.0.7}
  org.evrete.runtime.evaluation          {version=3.0.7}
  org.evrete.spi.minimal                 {version=3.0.7}
  org.evrete.util                        {version=3.0.7}

[CAPABILITIES]

Provide-Capability
  osgi.service                           {objectClass=org.evrete.api.spi.ExpressionResolverProvider, effective:=active}
  osgi.serviceloader                     {osgi.serviceloader=org.evrete.api.spi.ExpressionResolverProvider, register:=org.evrete.spi.minimal.DefaultExpressionResolverProvider}
  osgi.serviceloader                     {osgi.serviceloader=org.evrete.api.spi.LiteralRhsCompiler, register:=org.evrete.spi.minimal.DefaultLiteralRhsCompiler}
  osgi.serviceloader                     {osgi.serviceloader=org.evrete.api.spi.MemoryFactoryProvider, register:=org.evrete.spi.minimal.DefaultMemoryFactoryProvider}
  osgi.serviceloader                     {osgi.serviceloader=org.evrete.api.spi.TypeResolverProvider, register:=org.evrete.spi.minimal.DefaultTypeResolverProvider}
  osgi.service                           {objectClass=org.evrete.api.spi.LiteralRhsCompiler, effective:=active}
  osgi.service                           {objectClass=org.evrete.api.spi.MemoryFactoryProvider, effective:=active}
  osgi.service                           {objectClass=org.evrete.api.spi.TypeResolverProvider, effective:=active}
Require-Capability
  osgi.ee                                {filter:=(&(osgi.ee=JavaSE)(version=1.8))}
  osgi.extender                          {filter:=(&(osgi.extender=osgi.serviceloader.processor)(version>=1.0.0)(!(version>=2.0.0)))}
  osgi.extender                          {filter:=(&(osgi.extender=osgi.serviceloader.registrar)(version>=1.0.0)(!(version>=2.0.0)))}
  osgi.serviceloader                     {filter:=(osgi.serviceloader=org.evrete.api.spi.DSLKnowledgeProvider), osgi.serviceloader=org.evrete.api.spi.DSLKnowledgeProvider}
  osgi.serviceloader                     {filter:=(osgi.serviceloader=org.evrete.api.spi.ExpressionResolverProvider), osgi.serviceloader=org.evrete.api.spi.ExpressionResolverProvider}
  osgi.serviceloader                     {filter:=(osgi.serviceloader=org.evrete.api.spi.LiteralRhsCompiler), osgi.serviceloader=org.evrete.api.spi.LiteralRhsCompiler}
  osgi.serviceloader                     {filter:=(osgi.serviceloader=org.evrete.api.spi.MemoryFactoryProvider), osgi.serviceloader=org.evrete.api.spi.MemoryFactoryProvider}
  osgi.serviceloader                     {filter:=(osgi.serviceloader=org.evrete.api.spi.TypeResolverProvider), osgi.serviceloader=org.evrete.api.spi.TypeResolverProvider}

[COMPONENTS]



[METATYPE]



[API USES]


[USES]

org.evrete                              org.evrete.api
                                        org.evrete.api.spi
                                        org.evrete.runtime
                                        org.evrete.runtime.async
org.evrete.api                          org.evrete
                                        org.evrete.runtime
                                        org.evrete.runtime.compiler
org.evrete.api.annotations              
org.evrete.api.spi                      org.evrete
                                        org.evrete.api
                                        org.evrete.runtime.compiler
org.evrete.collections                  org.evrete.api
                                        org.evrete.util
org.evrete.runtime                      org.evrete
                                        org.evrete.api
                                        org.evrete.api.spi
                                        org.evrete.collections
                                        org.evrete.runtime.async
                                        org.evrete.runtime.compiler
                                        org.evrete.runtime.evaluation
                                        org.evrete.util
org.evrete.runtime.async                org.evrete.api
                                        org.evrete.collections
                                        org.evrete.runtime
                                        org.evrete.runtime.evaluation
                                        org.evrete.util
org.evrete.runtime.compiler             javax.lang.model.element
                                        javax.tools
                                        org.evrete.api
                                        org.evrete.util
org.evrete.runtime.evaluation           org.evrete.api
                                        org.evrete.runtime
                                        org.evrete.util
org.evrete.spi.minimal                  org.evrete
                                        org.evrete.api
                                        org.evrete.api.spi
                                        org.evrete.collections
                                        org.evrete.runtime
                                        org.evrete.runtime.compiler
                                        org.evrete.util
org.evrete.util                         org.evrete
                                        org.evrete.api
                                        org.evrete.runtime
                                        org.evrete.runtime.evaluation


[USEDBY]

javax.lang.model.element                org.evrete.runtime.compiler
javax.tools                             org.evrete.runtime.compiler
org.evrete                              org.evrete.api
                                        org.evrete.api.spi
                                        org.evrete.runtime
                                        org.evrete.spi.minimal
                                        org.evrete.util
org.evrete.api                          org.evrete
                                        org.evrete.api.spi
                                        org.evrete.collections
                                        org.evrete.runtime
                                        org.evrete.runtime.async
                                        org.evrete.runtime.compiler
                                        org.evrete.runtime.evaluation
                                        org.evrete.spi.minimal
                                        org.evrete.util
org.evrete.api.spi                      org.evrete
                                        org.evrete.runtime
                                        org.evrete.spi.minimal
org.evrete.collections                  org.evrete.runtime
                                        org.evrete.runtime.async
                                        org.evrete.spi.minimal
org.evrete.runtime                      org.evrete
                                        org.evrete.api
                                        org.evrete.runtime.async
                                        org.evrete.runtime.evaluation
                                        org.evrete.spi.minimal
                                        org.evrete.util
org.evrete.runtime.async                org.evrete
                                        org.evrete.runtime
org.evrete.runtime.compiler             org.evrete.api
                                        org.evrete.api.spi
                                        org.evrete.runtime
                                        org.evrete.spi.minimal
org.evrete.runtime.evaluation           org.evrete.runtime
                                        org.evrete.runtime.async
                                        org.evrete.util
org.evrete.util                         org.evrete.collections
                                        org.evrete.runtime
                                        org.evrete.runtime.async
                                        org.evrete.runtime.compiler
                                        org.evrete.runtime.evaluation
                                        org.evrete.spi.minimal


```  
---
Core Manifest - Plain:
```
Manifest-Version: 1.0
Created-By: Maven JAR Plugin 3.3.0
Build-Jdk-Spec: 22
Bundle-Description: Java Rule Engine
Bundle-DocURL: https://www.evrete.org/evrete-core
Bundle-License: "MIT License";link="https://www.opensource.org/licenses/
 mit-license"
Bundle-ManifestVersion: 2
Bundle-Name: evrete-core
Bundle-SCM: url="https://github.com/evrete/evrete/evrete-core",connectio
 n="scm:git:https://github.com/evrete/evrete.git/evrete-core",developer-
 connection="scm:git:https://github.com/evrete/evrete.git/evrete-core",t
 ag=HEAD
Bundle-SymbolicName: evrete-core
Bundle-Version: 3.0.7.202402081653
Export-Package: org.evrete;uses:="org.evrete.api,org.evrete.api.spi,org.
 evrete.runtime.async";version="3.0.7",org.evrete.api;uses:="org.evrete,
 org.evrete.runtime,org.evrete.runtime.compiler";version="3.0.7",org.evr
 ete.api.annotations;version="3.0.7",org.evrete.api.spi;uses:="org.evret
 e,org.evrete.api,org.evrete.runtime.compiler";version="3.0.7",org.evret
 e.collections;uses:="org.evrete.api";version="3.0.7",org.evrete.runtime
 ;uses:="org.evrete,org.evrete.api,org.evrete.collections,org.evrete.run
 time.compiler,org.evrete.runtime.evaluation,org.evrete.util";version="3
 .0.7",org.evrete.runtime.async;uses:="org.evrete.runtime,org.evrete.run
 time.evaluation,org.evrete.util";version="3.0.7",org.evrete.runtime.com
 piler;uses:="javax.lang.model.element,javax.tools,org.evrete.api";versi
 on="3.0.7",org.evrete.runtime.evaluation;uses:="org.evrete.api,org.evre
 te.runtime,org.evrete.util";version="3.0.7",org.evrete.spi.minimal;uses
 :="org.evrete.api,org.evrete.api.spi,org.evrete.runtime.compiler";versi
 on="3.0.7",org.evrete.util;uses:="org.evrete,org.evrete.api,org.evrete.
 runtime,org.evrete.runtime.evaluation";version="3.0.7"
Implementation-Title: Java Rule Engine
Implementation-URL: https://www.evrete.org
Implementation-Version: 3.0.07-SNAPSHOT
Import-Package: javax.lang.model.element,javax.tools,org.evrete,org.evre
 te.api,org.evrete.api.spi,org.evrete.collections,org.evrete.runtime,org
 .evrete.runtime.async,org.evrete.runtime.compiler,org.evrete.runtime.ev
 aluation,org.evrete.util
Provide-Capability: osgi.service;objectClass:List<String>="org.evrete.ap
 i.spi.ExpressionResolverProvider";effective:=active,osgi.service;object
 Class:List<String>="org.evrete.api.spi.LiteralRhsCompiler";effective:=a
 ctive,osgi.service;objectClass:List<String>="org.evrete.api.spi.MemoryF
 actoryProvider";effective:=active,osgi.service;objectClass:List<String>
 ="org.evrete.api.spi.TypeResolverProvider";effective:=active,osgi.servi
 celoader;osgi.serviceloader="org.evrete.api.spi.ExpressionResolverProvi
 der";register:="org.evrete.spi.minimal.DefaultExpressionResolverProvide
 r",osgi.serviceloader;osgi.serviceloader="org.evrete.api.spi.LiteralRhs
 Compiler";register:="org.evrete.spi.minimal.DefaultLiteralRhsCompiler",
 osgi.serviceloader;osgi.serviceloader="org.evrete.api.spi.MemoryFactory
 Provider";register:="org.evrete.spi.minimal.DefaultMemoryFactoryProvide
 r",osgi.serviceloader;osgi.serviceloader="org.evrete.api.spi.TypeResolv
 erProvider";register:="org.evrete.spi.minimal.DefaultTypeResolverProvid
 er"
Require-Capability: osgi.extender;filter:="(&(osgi.extender=osgi.service
 loader.processor)(version>=1.0.0)(!(version>=2.0.0)))",osgi.extender;fi
 lter:="(&(osgi.extender=osgi.serviceloader.registrar)(version>=1.0.0)(!
 (version>=2.0.0)))",osgi.serviceloader;filter:="(osgi.serviceloader=org
 .evrete.api.spi.DSLKnowledgeProvider)";osgi.serviceloader="org.evrete.a
 pi.spi.DSLKnowledgeProvider",osgi.serviceloader;filter:="(osgi.servicel
 oader=org.evrete.api.spi.ExpressionResolverProvider)";osgi.serviceloade
 r="org.evrete.api.spi.ExpressionResolverProvider",osgi.serviceloader;fi
 lter:="(osgi.serviceloader=org.evrete.api.spi.LiteralRhsCompiler)";osgi
 .serviceloader="org.evrete.api.spi.LiteralRhsCompiler",osgi.serviceload
 er;filter:="(osgi.serviceloader=org.evrete.api.spi.MemoryFactoryProvide
 r)";osgi.serviceloader="org.evrete.api.spi.MemoryFactoryProvider",osgi.
 serviceloader;filter:="(osgi.serviceloader=org.evrete.api.spi.TypeResol
 verProvider)";osgi.serviceloader="org.evrete.api.spi.TypeResolverProvid
 er",osgi.ee;filter:="(&(osgi.ee=JavaSE)(version=1.8))"
SPDX-License-Identifier: MIT License

  ```