### PR TITLE
fix: correct toString() for SessionFactGroup

### DIFF
--- a/evrete-core/src/main/java/org/evrete/runtime/SessionFactGroup.java
+++ b/evrete-core/src/main/java/org/evrete/runtime/SessionFactGroup.java
@@ -59,7 +59,7 @@ abstract class SessionFactGroup extends KnowledgeFactGroup {
     public String toString() {
         return "{" +
                 "plain=" + isPlain() +
-                "facts= " + FactType.toSimpleDebugString(factTypes) +
+                ", facts=" + FactType.toSimpleDebugString(factTypes) +
                 '}';
     }
 }


### PR DESCRIPTION
The toString() of SessionFactGroup was missing a comma and had an extra whitespace before the FactTypes array.